### PR TITLE
Fix Terraform health check timeout

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -79,6 +79,8 @@ resource "digitalocean_app" "mlb_stats" {
         http_path             = "/actuator/health"
         initial_delay_seconds = 60
         period_seconds        = 30
+        timeout_seconds       = 10
+        failure_threshold     = 3
       }
 
       # Environment variables


### PR DESCRIPTION
## Summary
- Add `timeout_seconds = 10` to health check configuration
- Add `failure_threshold = 3` to limit retry attempts

This prevents Terraform from waiting indefinitely when the DigitalOcean app health checks fail during `terraform apply`.

## Test plan
- [ ] Run `terraform plan` to verify config is valid
- [ ] Run `terraform apply` - should complete or fail within reasonable time instead of hanging

🤖 Generated with [Claude Code](https://claude.com/claude-code)