### PR TITLE
Add OAuth paths to Vite dev proxy

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -10,6 +10,14 @@ export default defineConfig({
         target: 'http://localhost:8080',
         changeOrigin: true,
       },
+      '/oauth2': {
+        target: 'http://localhost:8080',
+        changeOrigin: true,
+      },
+      '/login/oauth2': {
+        target: 'http://localhost:8080',
+        changeOrigin: true,
+      },
     },
   },
 })


### PR DESCRIPTION
## Summary
- Add `/oauth2` and `/login/oauth2` to Vite proxy configuration
- Fixes OAuth login flow in local development

Without this, the OAuth paths were handled by the frontend router instead of being proxied to the backend, causing immediate redirect back to /login.

## Test plan
- [ ] Run frontend with `npm run dev`
- [ ] Click login button
- [ ] Should redirect to Google OAuth (not back to /login)

🤖 Generated with [Claude Code](https://claude.com/claude-code)