### PR TITLE
Fix ClassCastException in AuthController

### DIFF
--- a/backend/src/main/java/com/mlbstats/api/controller/AuthController.java
+++ b/backend/src/main/java/com/mlbstats/api/controller/AuthController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.HashMap;
 import java.util.Map;
 
 @RestController
@@ -14,17 +15,20 @@ import java.util.Map;
 public class AuthController {
 
     @GetMapping("/me")
-    public ResponseEntity<?> getCurrentUser(@AuthenticationPrincipal OAuth2User principal) {
+    public ResponseEntity<Map<String, Object>> getCurrentUser(@AuthenticationPrincipal OAuth2User principal) {
+        Map<String, Object> response = new HashMap<>();
+
         if (principal == null) {
-            return ResponseEntity.ok(Map.of("authenticated", false));
+            response.put("authenticated", false);
+            return ResponseEntity.ok(response);
         }
 
-        return ResponseEntity.ok(Map.of(
-            "authenticated", true,
-            "name", principal.getAttribute("name"),
-            "email", principal.getAttribute("email"),
-            "picture", principal.getAttribute("picture")
-        ));
+        response.put("authenticated", true);
+        response.put("name", principal.getAttribute("name"));
+        response.put("email", principal.getAttribute("email"));
+        response.put("picture", principal.getAttribute("picture"));
+
+        return ResponseEntity.ok(response);
     }
 
     @GetMapping("/status")


### PR DESCRIPTION
## Summary
- Replace `Map.of()` with `HashMap` in `/api/auth/me` endpoint
- Fixes ClassCastException when OAuth attributes are null or have unexpected types

The `Map.of()` method has strict type inference and doesn't allow null values, causing a `String cannot be cast to Boolean` error during OAuth login.

## Test plan
- [ ] Login with Google OAuth
- [ ] Should successfully authenticate and show user info
- [ ] No ClassCastException in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)