### PR TITLE
Add homepage URL to GitHub repository

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -169,9 +169,10 @@ resource "digitalocean_record" "app_cname" {
 
 # GitHub Repository
 resource "github_repository" "mlb_stats" {
-  name        = local.github_repo
-  description = "Vibe Coded MLB Stats Webapp"
-  visibility  = "public"
+  name         = local.github_repo
+  description  = "Vibe Coded MLB Stats Webapp"
+  homepage_url = var.custom_domain != "" ? "https://${var.custom_domain}" : null
+  visibility   = "public"
 
   has_issues   = true
   has_projects = true
@@ -186,7 +187,7 @@ resource "github_branch_protection" "main" {
   pattern       = var.github_branch
 
   required_status_checks {
-    strict   = true # Require branch to be up to date before merging
+    strict = true # Require branch to be up to date before merging
     contexts = [
       "Frontend Build & Test",
       "Backend Build & Test"


### PR DESCRIPTION
## Summary
Add the production site link to the GitHub repository's About section by setting `homepage_url` on the `github_repository` Terraform resource.

## Changes
- Set `homepage_url` dynamically from `var.custom_domain` (e.g., `https://stats.cartergrove.me`)
- Uses conditional to only set when custom_domain is configured

## Test plan
- [ ] Run `terraform plan` to verify the change
- [ ] Run `terraform apply` to update the repository
- [ ] Verify link appears in GitHub repository About section

Closes #25

<img width="632" height="306" alt="image" src="https://github.com/user-attachments/assets/53688d33-415f-4127-920e-79eb148804d2" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)