### PR TITLE
Add user favorites for teams and players

### DIFF
--- a/backend/src/main/java/com/mlbstats/api/controller/FavoriteController.java
+++ b/backend/src/main/java/com/mlbstats/api/controller/FavoriteController.java
@@ -1,0 +1,110 @@
+package com.mlbstats.api.controller;
+
+import com.mlbstats.api.dto.PlayerDto;
+import com.mlbstats.api.dto.TeamDto;
+import com.mlbstats.api.service.FavoriteApiService;
+import com.mlbstats.common.security.AppUserPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/favorites")
+@Tag(name = "Favorites", description = "User favorites management")
+@RequiredArgsConstructor
+public class FavoriteController {
+
+    private final FavoriteApiService favoriteApiService;
+
+    // Team favorites
+
+    @GetMapping("/teams")
+    @Operation(summary = "Get favorite teams", description = "Returns the current user's favorite teams")
+    public ResponseEntity<List<TeamDto>> getFavoriteTeams(
+            @AuthenticationPrincipal OAuth2User principal) {
+        Long userId = getUserId(principal);
+        return ResponseEntity.ok(favoriteApiService.getFavoriteTeams(userId));
+    }
+
+    @GetMapping("/teams/{teamId}/status")
+    @Operation(summary = "Check if team is favorite", description = "Returns whether a team is in user's favorites")
+    public ResponseEntity<Map<String, Boolean>> isTeamFavorite(
+            @AuthenticationPrincipal OAuth2User principal,
+            @PathVariable Long teamId) {
+        Long userId = getUserId(principal);
+        boolean isFavorite = favoriteApiService.isTeamFavorite(userId, teamId);
+        return ResponseEntity.ok(Map.of("isFavorite", isFavorite));
+    }
+
+    @PostMapping("/teams/{teamId}")
+    @Operation(summary = "Add team to favorites", description = "Adds a team to the user's favorites")
+    public ResponseEntity<Map<String, String>> addTeamFavorite(
+            @AuthenticationPrincipal OAuth2User principal,
+            @PathVariable Long teamId) {
+        Long userId = getUserId(principal);
+        favoriteApiService.addTeamFavorite(userId, teamId);
+        return ResponseEntity.ok(Map.of("status", "added"));
+    }
+
+    @DeleteMapping("/teams/{teamId}")
+    @Operation(summary = "Remove team from favorites", description = "Removes a team from the user's favorites")
+    public ResponseEntity<Map<String, String>> removeTeamFavorite(
+            @AuthenticationPrincipal OAuth2User principal,
+            @PathVariable Long teamId) {
+        Long userId = getUserId(principal);
+        favoriteApiService.removeTeamFavorite(userId, teamId);
+        return ResponseEntity.ok(Map.of("status", "removed"));
+    }
+
+    // Player favorites
+
+    @GetMapping("/players")
+    @Operation(summary = "Get favorite players", description = "Returns the current user's favorite players")
+    public ResponseEntity<List<PlayerDto>> getFavoritePlayers(
+            @AuthenticationPrincipal OAuth2User principal) {
+        Long userId = getUserId(principal);
+        return ResponseEntity.ok(favoriteApiService.getFavoritePlayers(userId));
+    }
+
+    @GetMapping("/players/{playerId}/status")
+    @Operation(summary = "Check if player is favorite", description = "Returns whether a player is in user's favorites")
+    public ResponseEntity<Map<String, Boolean>> isPlayerFavorite(
+            @AuthenticationPrincipal OAuth2User principal,
+            @PathVariable Long playerId) {
+        Long userId = getUserId(principal);
+        boolean isFavorite = favoriteApiService.isPlayerFavorite(userId, playerId);
+        return ResponseEntity.ok(Map.of("isFavorite", isFavorite));
+    }
+
+    @PostMapping("/players/{playerId}")
+    @Operation(summary = "Add player to favorites", description = "Adds a player to the user's favorites")
+    public ResponseEntity<Map<String, String>> addPlayerFavorite(
+            @AuthenticationPrincipal OAuth2User principal,
+            @PathVariable Long playerId) {
+        Long userId = getUserId(principal);
+        favoriteApiService.addPlayerFavorite(userId, playerId);
+        return ResponseEntity.ok(Map.of("status", "added"));
+    }
+
+    @DeleteMapping("/players/{playerId}")
+    @Operation(summary = "Remove player from favorites", description = "Removes a player from the user's favorites")
+    public ResponseEntity<Map<String, String>> removePlayerFavorite(
+            @AuthenticationPrincipal OAuth2User principal,
+            @PathVariable Long playerId) {
+        Long userId = getUserId(principal);
+        favoriteApiService.removePlayerFavorite(userId, playerId);
+        return ResponseEntity.ok(Map.of("status", "removed"));
+    }
+
+    private Long getUserId(OAuth2User principal) {
+        AppUserPrincipal appUserPrincipal = (AppUserPrincipal) principal;
+        return appUserPrincipal.getAppUser().getId();
+    }
+}

--- a/backend/src/main/java/com/mlbstats/api/service/FavoriteApiService.java
+++ b/backend/src/main/java/com/mlbstats/api/service/FavoriteApiService.java
@@ -1,0 +1,92 @@
+package com.mlbstats.api.service;
+
+import com.mlbstats.api.dto.PlayerDto;
+import com.mlbstats.api.dto.TeamDto;
+import com.mlbstats.common.exception.ResourceNotFoundException;
+import com.mlbstats.domain.player.Player;
+import com.mlbstats.domain.player.PlayerRepository;
+import com.mlbstats.domain.team.Team;
+import com.mlbstats.domain.team.TeamRepository;
+import com.mlbstats.domain.user.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class FavoriteApiService {
+
+    private final UserFavoriteTeamRepository favoriteTeamRepository;
+    private final UserFavoritePlayerRepository favoritePlayerRepository;
+    private final AppUserRepository userRepository;
+    private final TeamRepository teamRepository;
+    private final PlayerRepository playerRepository;
+
+    // Team favorites
+
+    @Transactional(readOnly = true)
+    public List<TeamDto> getFavoriteTeams(Long userId) {
+        return favoriteTeamRepository.findByUserIdWithTeam(userId).stream()
+                .map(f -> TeamDto.fromEntity(f.getTeam()))
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public boolean isTeamFavorite(Long userId, Long teamId) {
+        return favoriteTeamRepository.existsByUserIdAndTeamId(userId, teamId);
+    }
+
+    @Transactional
+    public void addTeamFavorite(Long userId, Long teamId) {
+        if (favoriteTeamRepository.existsByUserIdAndTeamId(userId, teamId)) {
+            return; // Already a favorite
+        }
+
+        AppUser user = userRepository.findById(userId)
+                .orElseThrow(() -> new ResourceNotFoundException("User", userId));
+        Team team = teamRepository.findById(teamId)
+                .orElseThrow(() -> new ResourceNotFoundException("Team", teamId));
+
+        favoriteTeamRepository.save(new UserFavoriteTeam(user, team));
+    }
+
+    @Transactional
+    public void removeTeamFavorite(Long userId, Long teamId) {
+        favoriteTeamRepository.deleteByUserIdAndTeamId(userId, teamId);
+    }
+
+    // Player favorites
+
+    @Transactional(readOnly = true)
+    public List<PlayerDto> getFavoritePlayers(Long userId) {
+        return favoritePlayerRepository.findByUserIdWithPlayer(userId).stream()
+                .map(f -> PlayerDto.fromEntity(f.getPlayer()))
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public boolean isPlayerFavorite(Long userId, Long playerId) {
+        return favoritePlayerRepository.existsByUserIdAndPlayerId(userId, playerId);
+    }
+
+    @Transactional
+    public void addPlayerFavorite(Long userId, Long playerId) {
+        if (favoritePlayerRepository.existsByUserIdAndPlayerId(userId, playerId)) {
+            return; // Already a favorite
+        }
+
+        AppUser user = userRepository.findById(userId)
+                .orElseThrow(() -> new ResourceNotFoundException("User", userId));
+        Player player = playerRepository.findById(playerId)
+                .orElseThrow(() -> new ResourceNotFoundException("Player", playerId));
+
+        favoritePlayerRepository.save(new UserFavoritePlayer(user, player));
+    }
+
+    @Transactional
+    public void removePlayerFavorite(Long userId, Long playerId) {
+        favoritePlayerRepository.deleteByUserIdAndPlayerId(userId, playerId);
+    }
+}

--- a/backend/src/main/java/com/mlbstats/domain/user/UserFavoritePlayer.java
+++ b/backend/src/main/java/com/mlbstats/domain/user/UserFavoritePlayer.java
@@ -1,0 +1,42 @@
+package com.mlbstats.domain.user;
+
+import com.mlbstats.domain.player.Player;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "user_favorite_players")
+@Getter
+@Setter
+@NoArgsConstructor
+public class UserFavoritePlayer {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private AppUser user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "player_id", nullable = false)
+    private Player player;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+    }
+
+    public UserFavoritePlayer(AppUser user, Player player) {
+        this.user = user;
+        this.player = player;
+    }
+}

--- a/backend/src/main/java/com/mlbstats/domain/user/UserFavoritePlayerRepository.java
+++ b/backend/src/main/java/com/mlbstats/domain/user/UserFavoritePlayerRepository.java
@@ -1,0 +1,21 @@
+package com.mlbstats.domain.user;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface UserFavoritePlayerRepository extends JpaRepository<UserFavoritePlayer, Long> {
+
+    @Query("SELECT f FROM UserFavoritePlayer f JOIN FETCH f.player WHERE f.user.id = :userId ORDER BY f.player.fullName")
+    List<UserFavoritePlayer> findByUserIdWithPlayer(Long userId);
+
+    Optional<UserFavoritePlayer> findByUserIdAndPlayerId(Long userId, Long playerId);
+
+    void deleteByUserIdAndPlayerId(Long userId, Long playerId);
+
+    boolean existsByUserIdAndPlayerId(Long userId, Long playerId);
+}

--- a/backend/src/main/java/com/mlbstats/domain/user/UserFavoriteTeam.java
+++ b/backend/src/main/java/com/mlbstats/domain/user/UserFavoriteTeam.java
@@ -1,0 +1,42 @@
+package com.mlbstats.domain.user;
+
+import com.mlbstats.domain.team.Team;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "user_favorite_teams")
+@Getter
+@Setter
+@NoArgsConstructor
+public class UserFavoriteTeam {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private AppUser user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "team_id", nullable = false)
+    private Team team;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+    }
+
+    public UserFavoriteTeam(AppUser user, Team team) {
+        this.user = user;
+        this.team = team;
+    }
+}

--- a/backend/src/main/java/com/mlbstats/domain/user/UserFavoriteTeamRepository.java
+++ b/backend/src/main/java/com/mlbstats/domain/user/UserFavoriteTeamRepository.java
@@ -1,0 +1,21 @@
+package com.mlbstats.domain.user;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface UserFavoriteTeamRepository extends JpaRepository<UserFavoriteTeam, Long> {
+
+    @Query("SELECT f FROM UserFavoriteTeam f JOIN FETCH f.team WHERE f.user.id = :userId ORDER BY f.team.name")
+    List<UserFavoriteTeam> findByUserIdWithTeam(Long userId);
+
+    Optional<UserFavoriteTeam> findByUserIdAndTeamId(Long userId, Long teamId);
+
+    void deleteByUserIdAndTeamId(Long userId, Long teamId);
+
+    boolean existsByUserIdAndTeamId(Long userId, Long teamId);
+}

--- a/backend/src/main/resources/db/migration/V3__user_favorites.sql
+++ b/backend/src/main/resources/db/migration/V3__user_favorites.sql
@@ -1,0 +1,21 @@
+-- User favorite teams
+CREATE TABLE user_favorite_teams (
+    id BIGSERIAL PRIMARY KEY,
+    user_id BIGINT NOT NULL REFERENCES app_users(id) ON DELETE CASCADE,
+    team_id BIGINT NOT NULL REFERENCES teams(id) ON DELETE CASCADE,
+    created_at TIMESTAMP DEFAULT NOW(),
+    UNIQUE(user_id, team_id)
+);
+
+-- User favorite players
+CREATE TABLE user_favorite_players (
+    id BIGSERIAL PRIMARY KEY,
+    user_id BIGINT NOT NULL REFERENCES app_users(id) ON DELETE CASCADE,
+    player_id BIGINT NOT NULL REFERENCES players(id) ON DELETE CASCADE,
+    created_at TIMESTAMP DEFAULT NOW(),
+    UNIQUE(user_id, player_id)
+);
+
+-- Indexes for faster queries
+CREATE INDEX idx_user_favorite_teams_user ON user_favorite_teams(user_id);
+CREATE INDEX idx_user_favorite_players_user ON user_favorite_players(user_id);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,6 +13,7 @@ import GamesPage from './pages/GamesPage';
 import GameDetailPage from './pages/GameDetailPage';
 import LoginPage from './pages/LoginPage';
 import AdminPage from './pages/AdminPage';
+import AccountPage from './pages/AccountPage';
 
 function AppContent() {
   const { isAuthenticated, isLoading } = useAuth();
@@ -48,6 +49,7 @@ function AppContent() {
           <Route path="/players/:id" element={<PlayerDetailPage />} />
           <Route path="/games" element={<GamesPage />} />
           <Route path="/games/:id" element={<GameDetailPage />} />
+          <Route path="/account" element={<AccountPage />} />
           <Route path="/admin" element={<AdminPage />} />
           <Route path="/login" element={<Navigate to="/" replace />} />
         </Routes>

--- a/frontend/src/components/common/FavoriteButton.tsx
+++ b/frontend/src/components/common/FavoriteButton.tsx
@@ -1,0 +1,40 @@
+interface FavoriteButtonProps {
+  isFavorite: boolean;
+  loading: boolean;
+  toggling: boolean;
+  onToggle: () => void;
+}
+
+function FavoriteButton({ isFavorite, loading, toggling, onToggle }: FavoriteButtonProps) {
+  if (loading) {
+    return null;
+  }
+
+  return (
+    <button
+      onClick={onToggle}
+      disabled={toggling}
+      title={isFavorite ? 'Remove from favorites' : 'Add to favorites'}
+      style={{
+        padding: '8px 16px',
+        backgroundColor: isFavorite ? 'var(--secondary-color)' : 'transparent',
+        color: isFavorite ? 'white' : 'var(--secondary-color)',
+        border: `2px solid var(--secondary-color)`,
+        borderRadius: '4px',
+        cursor: toggling ? 'wait' : 'pointer',
+        display: 'flex',
+        alignItems: 'center',
+        gap: '6px',
+        fontSize: '14px',
+        fontWeight: '600',
+        opacity: toggling ? 0.7 : 1,
+        transition: 'all 0.2s ease',
+      }}
+    >
+      <span style={{ fontSize: '16px' }}>{isFavorite ? '\u2605' : '\u2606'}</span>
+      {isFavorite ? 'Favorited' : 'Favorite'}
+    </button>
+  );
+}
+
+export default FavoriteButton;

--- a/frontend/src/components/common/Navigation.tsx
+++ b/frontend/src/components/common/Navigation.tsx
@@ -27,6 +27,11 @@ function Navigation() {
             Games
           </NavLink>
         </li>
+        <li>
+          <NavLink to="/account" className={({ isActive }) => isActive ? 'active' : ''}>
+            My Favorites
+          </NavLink>
+        </li>
         {isAdmin && (
           <li>
             <NavLink to="/admin" className={({ isActive }) => isActive ? 'active' : ''}>

--- a/frontend/src/hooks/useFavorite.ts
+++ b/frontend/src/hooks/useFavorite.ts
@@ -1,0 +1,129 @@
+import { useState, useEffect, useCallback } from 'react';
+import {
+  isTeamFavorite,
+  addTeamFavorite,
+  removeTeamFavorite,
+  isPlayerFavorite,
+  addPlayerFavorite,
+  removePlayerFavorite,
+} from '../services/api';
+
+export function useTeamFavorite(teamId: number | undefined) {
+  const [isFavorite, setIsFavorite] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [toggling, setToggling] = useState(false);
+
+  useEffect(() => {
+    if (!teamId) {
+      setLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    const id = teamId;
+
+    async function checkFavorite() {
+      try {
+        const result = await isTeamFavorite(id);
+        if (!cancelled) {
+          setIsFavorite(result);
+        }
+      } catch (err) {
+        // User might not be authenticated, silently fail
+        if (!cancelled) {
+          setIsFavorite(false);
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    }
+
+    checkFavorite();
+    return () => {
+      cancelled = true;
+    };
+  }, [teamId]);
+
+  const toggleFavorite = useCallback(async () => {
+    if (!teamId || toggling) return;
+
+    setToggling(true);
+    try {
+      if (isFavorite) {
+        await removeTeamFavorite(teamId);
+        setIsFavorite(false);
+      } else {
+        await addTeamFavorite(teamId);
+        setIsFavorite(true);
+      }
+    } catch (err) {
+      console.error('Failed to toggle team favorite:', err);
+    } finally {
+      setToggling(false);
+    }
+  }, [teamId, isFavorite, toggling]);
+
+  return { isFavorite, loading, toggling, toggleFavorite };
+}
+
+export function usePlayerFavorite(playerId: number | undefined) {
+  const [isFavorite, setIsFavorite] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [toggling, setToggling] = useState(false);
+
+  useEffect(() => {
+    if (!playerId) {
+      setLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    const id = playerId;
+
+    async function checkFavorite() {
+      try {
+        const result = await isPlayerFavorite(id);
+        if (!cancelled) {
+          setIsFavorite(result);
+        }
+      } catch (err) {
+        // User might not be authenticated, silently fail
+        if (!cancelled) {
+          setIsFavorite(false);
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    }
+
+    checkFavorite();
+    return () => {
+      cancelled = true;
+    };
+  }, [playerId]);
+
+  const toggleFavorite = useCallback(async () => {
+    if (!playerId || toggling) return;
+
+    setToggling(true);
+    try {
+      if (isFavorite) {
+        await removePlayerFavorite(playerId);
+        setIsFavorite(false);
+      } else {
+        await addPlayerFavorite(playerId);
+        setIsFavorite(true);
+      }
+    } catch (err) {
+      console.error('Failed to toggle player favorite:', err);
+    } finally {
+      setToggling(false);
+    }
+  }, [playerId, isFavorite, toggling]);
+
+  return { isFavorite, loading, toggling, toggleFavorite };
+}

--- a/frontend/src/pages/AccountPage.css
+++ b/frontend/src/pages/AccountPage.css
@@ -1,0 +1,169 @@
+.account-page {
+  padding: 20px;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.account-header {
+  margin-bottom: 24px;
+}
+
+.account-profile {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.account-avatar {
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.account-info h1 {
+  margin: 0;
+  color: var(--text-color);
+  font-size: 24px;
+}
+
+.account-email {
+  margin: 4px 0 0;
+  color: var(--text-light);
+}
+
+.favorites-section h2 {
+  margin-bottom: 16px;
+  color: var(--primary-color);
+}
+
+.favorites-tabs {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 24px;
+  border-bottom: 2px solid var(--border-color);
+  padding-bottom: 0;
+}
+
+.favorites-tabs .tab-button {
+  padding: 12px 24px;
+  border: none;
+  background: none;
+  cursor: pointer;
+  font-size: 16px;
+  color: var(--text-light);
+  border-bottom: 2px solid transparent;
+  margin-bottom: -2px;
+  transition: all 0.2s;
+}
+
+.favorites-tabs .tab-button:hover {
+  color: var(--text-color);
+}
+
+.favorites-tabs .tab-button.active {
+  color: var(--primary-color);
+  border-bottom-color: var(--primary-color);
+  font-weight: 600;
+}
+
+.favorites-content {
+  background: var(--card-background);
+  border-radius: 8px;
+  padding: 24px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.loading-text {
+  color: var(--text-light);
+  text-align: center;
+  padding: 24px;
+}
+
+.empty-state {
+  text-align: center;
+  padding: 48px 24px;
+  color: var(--text-light);
+}
+
+.empty-state p {
+  margin-bottom: 16px;
+}
+
+.browse-link {
+  display: inline-block;
+  padding: 12px 24px;
+  background: var(--primary-color);
+  color: white;
+  text-decoration: none;
+  border-radius: 6px;
+  font-weight: 500;
+  transition: opacity 0.2s;
+}
+
+.browse-link:hover {
+  opacity: 0.9;
+}
+
+.favorites-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 16px;
+}
+
+.favorite-card {
+  display: block;
+  padding: 20px;
+  background: var(--background-color);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  text-decoration: none;
+  transition: all 0.2s;
+}
+
+.favorite-card:hover {
+  border-color: var(--primary-color);
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+
+.favorite-abbrev {
+  font-size: 32px;
+  font-weight: bold;
+  color: var(--primary-color);
+  margin-bottom: 8px;
+}
+
+.favorite-number {
+  width: 48px;
+  height: 48px;
+  background: var(--primary-color);
+  color: white;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 20px;
+  font-weight: bold;
+  margin-bottom: 12px;
+}
+
+.favorite-name {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--text-color);
+  margin-bottom: 4px;
+}
+
+.favorite-meta {
+  font-size: 13px;
+  color: var(--text-light);
+}
+
+.account-page .error {
+  color: var(--secondary-color);
+  padding: 12px;
+  background: rgba(191, 13, 62, 0.1);
+  border-radius: 4px;
+  margin-bottom: 16px;
+}

--- a/frontend/src/pages/AccountPage.tsx
+++ b/frontend/src/pages/AccountPage.tsx
@@ -1,0 +1,149 @@
+import { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
+import { useAuth } from '../contexts/AuthContext';
+import { Team } from '../types/team';
+import { Player } from '../types/player';
+import { getFavoriteTeams, getFavoritePlayers } from '../services/api';
+import './AccountPage.css';
+
+type Tab = 'teams' | 'players';
+
+function AccountPage() {
+  const { user } = useAuth();
+  const [activeTab, setActiveTab] = useState<Tab>('teams');
+  const [favoriteTeams, setFavoriteTeams] = useState<Team[]>([]);
+  const [favoritePlayers, setFavoritePlayers] = useState<Player[]>([]);
+  const [teamsLoading, setTeamsLoading] = useState(true);
+  const [playersLoading, setPlayersLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    loadFavoriteTeams();
+    loadFavoritePlayers();
+  }, []);
+
+  const loadFavoriteTeams = async () => {
+    try {
+      const teams = await getFavoriteTeams();
+      setFavoriteTeams(teams);
+    } catch (err) {
+      setError('Failed to load favorite teams');
+    } finally {
+      setTeamsLoading(false);
+    }
+  };
+
+  const loadFavoritePlayers = async () => {
+    try {
+      const players = await getFavoritePlayers();
+      setFavoritePlayers(players);
+    } catch (err) {
+      setError('Failed to load favorite players');
+    } finally {
+      setPlayersLoading(false);
+    }
+  };
+
+  return (
+    <div className="account-page">
+      <div className="account-header card">
+        <div className="account-profile">
+          {user?.picture && (
+            <img
+              src={user.picture}
+              alt=""
+              className="account-avatar"
+            />
+          )}
+          <div className="account-info">
+            <h1>{user?.name || 'User'}</h1>
+            <p className="account-email">{user?.email}</p>
+          </div>
+        </div>
+      </div>
+
+      <div className="favorites-section">
+        <h2>My Favorites</h2>
+
+        <div className="favorites-tabs">
+          <button
+            className={`tab-button ${activeTab === 'teams' ? 'active' : ''}`}
+            onClick={() => setActiveTab('teams')}
+          >
+            Teams ({favoriteTeams.length})
+          </button>
+          <button
+            className={`tab-button ${activeTab === 'players' ? 'active' : ''}`}
+            onClick={() => setActiveTab('players')}
+          >
+            Players ({favoritePlayers.length})
+          </button>
+        </div>
+
+        {error && <p className="error">{error}</p>}
+
+        <div className="favorites-content">
+          {activeTab === 'teams' && (
+            <div className="favorites-list">
+              {teamsLoading ? (
+                <p className="loading-text">Loading teams...</p>
+              ) : favoriteTeams.length === 0 ? (
+                <div className="empty-state">
+                  <p>You haven't added any favorite teams yet.</p>
+                  <Link to="/teams" className="browse-link">Browse teams</Link>
+                </div>
+              ) : (
+                <div className="favorites-grid">
+                  {favoriteTeams.map((team) => (
+                    <Link
+                      key={team.id}
+                      to={`/teams/${team.id}`}
+                      className="favorite-card"
+                    >
+                      <div className="favorite-abbrev">{team.abbreviation}</div>
+                      <div className="favorite-name">{team.name}</div>
+                      <div className="favorite-meta">
+                        {team.league} - {team.division}
+                      </div>
+                    </Link>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+
+          {activeTab === 'players' && (
+            <div className="favorites-list">
+              {playersLoading ? (
+                <p className="loading-text">Loading players...</p>
+              ) : favoritePlayers.length === 0 ? (
+                <div className="empty-state">
+                  <p>You haven't added any favorite players yet.</p>
+                  <Link to="/players" className="browse-link">Browse players</Link>
+                </div>
+              ) : (
+                <div className="favorites-grid">
+                  {favoritePlayers.map((player) => (
+                    <Link
+                      key={player.id}
+                      to={`/players/${player.id}`}
+                      className="favorite-card"
+                    >
+                      <div className="favorite-number">{player.jerseyNumber || '?'}</div>
+                      <div className="favorite-name">{player.fullName}</div>
+                      <div className="favorite-meta">
+                        {player.position || 'Position unknown'}
+                      </div>
+                    </Link>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default AccountPage;

--- a/frontend/src/pages/PlayerDetailPage.tsx
+++ b/frontend/src/pages/PlayerDetailPage.tsx
@@ -3,22 +3,25 @@ import { useParams } from 'react-router-dom';
 import { Player } from '../types/player';
 import { BattingStats, PitchingStats } from '../types/stats';
 import { getPlayer, getPlayerBattingStats, getPlayerPitchingStats } from '../services/api';
+import { usePlayerFavorite } from '../hooks/useFavorite';
 import PlayerStats from '../components/player/PlayerStats';
 import PlayerGameLog from '../components/player/PlayerGameLog';
+import FavoriteButton from '../components/common/FavoriteButton';
 
 function PlayerDetailPage() {
   const { id } = useParams<{ id: string }>();
+  const playerId = id ? parseInt(id) : undefined;
   const [player, setPlayer] = useState<Player | null>(null);
   const [battingStats, setBattingStats] = useState<BattingStats[]>([]);
   const [pitchingStats, setPitchingStats] = useState<PitchingStats[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const { isFavorite, loading: favoriteLoading, toggling, toggleFavorite } = usePlayerFavorite(playerId);
 
   useEffect(() => {
     async function fetchData() {
-      if (!id) return;
+      if (!playerId) return;
       try {
-        const playerId = parseInt(id);
         const [playerData, batting, pitching] = await Promise.all([
           getPlayer(playerId),
           getPlayerBattingStats(playerId).catch(() => []),
@@ -34,7 +37,7 @@ function PlayerDetailPage() {
       }
     }
     fetchData();
-  }, [id]);
+  }, [playerId]);
 
   if (loading) return <div className="loading">Loading player...</div>;
   if (error) return <div className="error">{error}</div>;
@@ -56,7 +59,7 @@ function PlayerDetailPage() {
           <div style={{
             width: '80px',
             height: '80px',
-            backgroundColor: '#002d72',
+            backgroundColor: 'var(--primary-color)',
             color: 'white',
             borderRadius: '50%',
             display: 'flex',
@@ -64,17 +67,26 @@ function PlayerDetailPage() {
             justifyContent: 'center',
             fontSize: '32px',
             fontWeight: 'bold',
+            flexShrink: 0,
           }}>
             {player.jerseyNumber || '?'}
           </div>
           <div style={{ flex: 1 }}>
-            <h1 style={{ margin: 0, fontSize: '28px' }}>{player.fullName}</h1>
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '16px' }}>
+              <h1 style={{ margin: 0, fontSize: '28px' }}>{player.fullName}</h1>
+              <FavoriteButton
+                isFavorite={isFavorite}
+                loading={favoriteLoading}
+                toggling={toggling}
+                onToggle={toggleFavorite}
+              />
+            </div>
             <div style={{ marginTop: '8px' }}>
               {player.position && (
                 <span style={{
                   display: 'inline-block',
                   padding: '4px 12px',
-                  backgroundColor: '#002d72',
+                  backgroundColor: 'var(--primary-color)',
                   color: 'white',
                   borderRadius: '4px',
                   fontSize: '14px',
@@ -84,25 +96,25 @@ function PlayerDetailPage() {
                 </span>
               )}
               {player.positionType && (
-                <span style={{ color: '#666', fontSize: '14px' }}>{player.positionType}</span>
+                <span style={{ color: 'var(--text-light)', fontSize: '14px' }}>{player.positionType}</span>
               )}
             </div>
 
             <div style={{ marginTop: '16px', display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: '16px' }}>
               <div>
-                <div style={{ fontSize: '12px', color: '#666', textTransform: 'uppercase' }}>Bats/Throws</div>
+                <div style={{ fontSize: '12px', color: 'var(--text-light)', textTransform: 'uppercase' }}>Bats/Throws</div>
                 <div style={{ fontWeight: '600' }}>{player.bats || '-'}/{player.throwsHand || '-'}</div>
               </div>
               <div>
-                <div style={{ fontSize: '12px', color: '#666', textTransform: 'uppercase' }}>Height/Weight</div>
+                <div style={{ fontSize: '12px', color: 'var(--text-light)', textTransform: 'uppercase' }}>Height/Weight</div>
                 <div style={{ fontWeight: '600' }}>{player.height || '-'} / {player.weight || '-'} lbs</div>
               </div>
               <div>
-                <div style={{ fontSize: '12px', color: '#666', textTransform: 'uppercase' }}>Birth Date</div>
+                <div style={{ fontSize: '12px', color: 'var(--text-light)', textTransform: 'uppercase' }}>Birth Date</div>
                 <div style={{ fontWeight: '600' }}>{formatDate(player.birthDate)}</div>
               </div>
               <div>
-                <div style={{ fontSize: '12px', color: '#666', textTransform: 'uppercase' }}>MLB Debut</div>
+                <div style={{ fontSize: '12px', color: 'var(--text-light)', textTransform: 'uppercase' }}>MLB Debut</div>
                 <div style={{ fontWeight: '600' }}>{formatDate(player.mlbDebutDate)}</div>
               </div>
             </div>

--- a/frontend/src/pages/TeamDetailPage.tsx
+++ b/frontend/src/pages/TeamDetailPage.tsx
@@ -4,12 +4,15 @@ import { Team, RosterEntry } from '../types/team';
 import { Game } from '../types/game';
 import { BattingStats } from '../types/stats';
 import { getTeam, getTeamRoster, getTeamGames, getTeamStats } from '../services/api';
+import { useTeamFavorite } from '../hooks/useFavorite';
 import TeamRoster from '../components/team/TeamRoster';
 import TeamStats from '../components/team/TeamStats';
 import GameSchedule from '../components/game/GameSchedule';
+import FavoriteButton from '../components/common/FavoriteButton';
 
 function TeamDetailPage() {
   const { id } = useParams<{ id: string }>();
+  const teamId = id ? parseInt(id) : undefined;
   const [team, setTeam] = useState<Team | null>(null);
   const [roster, setRoster] = useState<RosterEntry[]>([]);
   const [games, setGames] = useState<Game[]>([]);
@@ -17,12 +20,12 @@ function TeamDetailPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<'roster' | 'stats' | 'games'>('roster');
+  const { isFavorite, loading: favoriteLoading, toggling, toggleFavorite } = useTeamFavorite(teamId);
 
   useEffect(() => {
     async function fetchData() {
-      if (!id) return;
+      if (!teamId) return;
       try {
-        const teamId = parseInt(id);
         const [teamData, rosterData, gamesData, statsData] = await Promise.all([
           getTeam(teamId),
           getTeamRoster(teamId).catch(() => []),
@@ -40,7 +43,7 @@ function TeamDetailPage() {
       }
     }
     fetchData();
-  }, [id]);
+  }, [teamId]);
 
   if (loading) return <div className="loading">Loading team...</div>;
   if (error) return <div className="error">{error}</div>;
@@ -52,15 +55,21 @@ function TeamDetailPage() {
     <div>
       <div className="card" style={{ marginBottom: '24px' }}>
         <div style={{ display: 'flex', alignItems: 'center', gap: '16px' }}>
-          <div style={{ fontSize: '48px', fontWeight: 'bold', color: '#002d72' }}>
+          <div style={{ fontSize: '48px', fontWeight: 'bold', color: 'var(--primary-color)' }}>
             {team.abbreviation}
           </div>
-          <div>
+          <div style={{ flex: 1 }}>
             <h1 style={{ margin: 0, fontSize: '28px' }}>{team.name}</h1>
-            <p style={{ margin: '4px 0 0', color: '#666' }}>
+            <p style={{ margin: '4px 0 0', color: 'var(--text-light)' }}>
               {team.league} - {team.division} | {team.venueName}
             </p>
           </div>
+          <FavoriteButton
+            isFavorite={isFavorite}
+            loading={favoriteLoading}
+            toggling={toggling}
+            onToggle={toggleFavorite}
+          />
         </div>
       </div>
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -198,3 +198,64 @@ export async function updateUserRole(userId: number, role: 'USER' | 'ADMIN'): Pr
   }
   return response.json();
 }
+
+// Favorites
+export async function getFavoriteTeams(): Promise<Team[]> {
+  return fetchJson<Team[]>(`${API_BASE}/favorites/teams`);
+}
+
+export async function isTeamFavorite(teamId: number): Promise<boolean> {
+  const result = await fetchJson<{ isFavorite: boolean }>(`${API_BASE}/favorites/teams/${teamId}/status`);
+  return result.isFavorite;
+}
+
+export async function addTeamFavorite(teamId: number): Promise<{ status: string }> {
+  return postJson(`${API_BASE}/favorites/teams/${teamId}`);
+}
+
+export async function removeTeamFavorite(teamId: number): Promise<{ status: string }> {
+  const csrfToken = getCsrfToken();
+  const headers: HeadersInit = {};
+  if (csrfToken) {
+    headers['X-XSRF-TOKEN'] = csrfToken;
+  }
+  const response = await fetch(`${API_BASE}/favorites/teams/${teamId}`, {
+    method: 'DELETE',
+    credentials: 'include',
+    headers,
+  });
+  if (!response.ok) {
+    throw new Error(`API error: ${response.status}`);
+  }
+  return response.json();
+}
+
+export async function getFavoritePlayers(): Promise<Player[]> {
+  return fetchJson<Player[]>(`${API_BASE}/favorites/players`);
+}
+
+export async function isPlayerFavorite(playerId: number): Promise<boolean> {
+  const result = await fetchJson<{ isFavorite: boolean }>(`${API_BASE}/favorites/players/${playerId}/status`);
+  return result.isFavorite;
+}
+
+export async function addPlayerFavorite(playerId: number): Promise<{ status: string }> {
+  return postJson(`${API_BASE}/favorites/players/${playerId}`);
+}
+
+export async function removePlayerFavorite(playerId: number): Promise<{ status: string }> {
+  const csrfToken = getCsrfToken();
+  const headers: HeadersInit = {};
+  if (csrfToken) {
+    headers['X-XSRF-TOKEN'] = csrfToken;
+  }
+  const response = await fetch(`${API_BASE}/favorites/players/${playerId}`, {
+    method: 'DELETE',
+    credentials: 'include',
+    headers,
+  });
+  if (!response.ok) {
+    throw new Error(`API error: ${response.status}`);
+  }
+  return response.json();
+}


### PR DESCRIPTION
## Summary

- Users can mark teams and players as favorites from their detail pages
- New "My Favorites" page shows all favorited teams and players in a grid view
- Backend includes Flyway migration, JPA entities, repositories, service, and REST endpoints
- Frontend includes reusable FavoriteButton component and custom hooks for favorite state management

## Changes

### Backend
- `V3__user_favorites.sql` - Database migration for `user_favorite_teams` and `user_favorite_players` tables
- `UserFavoriteTeam` / `UserFavoritePlayer` - JPA entities with user/team/player relationships
- `FavoriteApiService` - Business logic for adding/removing/querying favorites
- `FavoriteController` - REST endpoints at `/api/favorites/teams/*` and `/api/favorites/players/*`

### Frontend
- `useFavorite.ts` - Custom hooks (`useTeamFavorite`, `usePlayerFavorite`) for managing favorite state
- `FavoriteButton.tsx` - Reusable toggle button component
- `TeamDetailPage.tsx` / `PlayerDetailPage.tsx` - Added favorite buttons to headers
- `AccountPage.tsx` - New page showing user's favorite teams and players
- `Navigation.tsx` - Added "My Favorites" link

## Test plan

- [ ] Navigate to a team detail page and click the Favorite button
- [ ] Verify the button toggles between "Favorite" and "Favorited" states
- [ ] Navigate to a player detail page and toggle favorite
- [ ] Go to "My Favorites" in navigation
- [ ] Verify favorited teams and players appear in the grid
- [ ] Click a favorite card to navigate to the detail page
- [ ] Remove a favorite and verify it disappears from the Account page

Closes #21

<img width="2206" height="1013" alt="image" src="https://github.com/user-attachments/assets/95863b1f-5fec-47b8-b3ec-604ec64048cb" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)