### PR TITLE
Add responsive styles for mobile and tablet

### DIFF
--- a/frontend/src/components/common/Header.css
+++ b/frontend/src/components/common/Header.css
@@ -57,3 +57,41 @@
 .logout-btn:hover {
   background: rgba(255, 255, 255, 0.3);
 }
+
+/* Responsive styles */
+@media (max-width: 768px) {
+  .header {
+    padding: 0 12px;
+  }
+
+  .header-right {
+    gap: 8px;
+  }
+
+  .user-name {
+    display: none;
+  }
+
+  .theme-toggle,
+  .logout-btn {
+    padding: 6px 8px;
+    font-size: 12px;
+  }
+}
+
+@media (max-width: 480px) {
+  .user-avatar {
+    width: 28px;
+    height: 28px;
+  }
+
+  .theme-toggle {
+    padding: 4px 6px;
+    font-size: 14px;
+  }
+
+  .logout-btn {
+    padding: 4px 8px;
+    font-size: 11px;
+  }
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -175,11 +175,42 @@ body {
   grid-template-columns: repeat(4, 1fr);
 }
 
+/* Tablet breakpoint */
+@media (max-width: 992px) {
+  .grid-4 {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+/* Mobile breakpoint */
 @media (max-width: 768px) {
+  .main-content {
+    padding: 12px;
+  }
+
   .grid-2,
   .grid-3,
   .grid-4 {
     grid-template-columns: 1fr;
+  }
+
+  .page-title {
+    font-size: 20px;
+  }
+
+  .card {
+    padding: 12px;
+  }
+}
+
+/* Small mobile */
+@media (max-width: 480px) {
+  .main-content {
+    padding: 8px;
+  }
+
+  .page-title {
+    font-size: 18px;
   }
 }
 
@@ -401,4 +432,308 @@ a:hover {
   font-weight: 600;
   margin-bottom: 16px;
   color: var(--primary-color);
+}
+
+/* ===========================================
+   RESPONSIVE STYLES
+   =========================================== */
+
+/* Navigation responsive */
+@media (max-width: 768px) {
+  .navigation {
+    padding: 0 12px;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .navigation ul {
+    gap: 0;
+    min-width: max-content;
+  }
+
+  .navigation a {
+    padding: 12px;
+    font-size: 14px;
+    white-space: nowrap;
+  }
+}
+
+/* Header responsive */
+@media (max-width: 768px) {
+  .header {
+    padding: 12px 16px;
+  }
+
+  .header h1 {
+    font-size: 18px;
+  }
+}
+
+/* Table responsive wrapper */
+.table-responsive {
+  width: 100%;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+@media (max-width: 768px) {
+  .data-table {
+    font-size: 12px;
+  }
+
+  .data-table th,
+  .data-table td {
+    padding: 8px 6px;
+  }
+}
+
+/* Search form responsive */
+@media (max-width: 768px) {
+  .search-input {
+    max-width: 100%;
+  }
+}
+
+@media (max-width: 480px) {
+  .search-form {
+    flex-direction: column;
+  }
+
+  .search-form .search-input {
+    width: 100%;
+    margin-bottom: 8px;
+  }
+
+  .search-form button {
+    width: 100%;
+  }
+}
+
+/* Pagination responsive */
+@media (max-width: 480px) {
+  .pagination {
+    flex-wrap: wrap;
+  }
+
+  .pagination button {
+    padding: 8px 12px;
+    font-size: 14px;
+  }
+}
+
+/* Date picker responsive */
+@media (max-width: 480px) {
+  .date-picker-container {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .date-picker-container input[type="date"] {
+    width: 100%;
+  }
+}
+
+/* Player/Team detail header */
+.detail-header {
+  display: flex;
+  align-items: flex-start;
+  gap: 24px;
+}
+
+.detail-header-image {
+  width: 100px;
+  height: 100px;
+  border-radius: 50%;
+  object-fit: cover;
+  flex-shrink: 0;
+  background-color: var(--border-color);
+}
+
+.detail-header-placeholder {
+  width: 100px;
+  height: 100px;
+  background-color: var(--primary-color);
+  color: white;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 32px;
+  font-weight: bold;
+  flex-shrink: 0;
+}
+
+.detail-header-content {
+  flex: 1;
+  min-width: 0;
+}
+
+.detail-header-title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.detail-header-title h1 {
+  margin: 0;
+  font-size: 28px;
+}
+
+.detail-stats-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+  margin-top: 16px;
+}
+
+.detail-stat-item {
+  min-width: 0;
+}
+
+.detail-stat-label {
+  font-size: 12px;
+  color: var(--text-light);
+  text-transform: uppercase;
+}
+
+.detail-stat-value {
+  font-weight: 600;
+}
+
+/* Team detail header (logo instead of circle) */
+.team-detail-logo {
+  width: 80px;
+  height: 80px;
+  object-fit: contain;
+  flex-shrink: 0;
+}
+
+.team-detail-abbrev {
+  font-size: 48px;
+  font-weight: bold;
+  color: var(--primary-color);
+  flex-shrink: 0;
+}
+
+@media (max-width: 768px) {
+  .detail-header {
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    gap: 16px;
+  }
+
+  .detail-header-image,
+  .detail-header-placeholder {
+    width: 80px;
+    height: 80px;
+    font-size: 24px;
+  }
+
+  .detail-header-title {
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .detail-header-title h1 {
+    font-size: 22px;
+  }
+
+  .detail-stats-grid {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 12px;
+  }
+
+  .team-detail-logo {
+    width: 64px;
+    height: 64px;
+  }
+
+  .team-detail-abbrev {
+    font-size: 36px;
+  }
+}
+
+@media (max-width: 480px) {
+  .detail-stats-grid {
+    grid-template-columns: 1fr 1fr;
+    gap: 8px;
+  }
+
+  .detail-stat-label {
+    font-size: 10px;
+  }
+
+  .detail-stat-value {
+    font-size: 14px;
+  }
+}
+
+/* Tab buttons responsive */
+.tab-buttons {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 16px;
+  flex-wrap: wrap;
+}
+
+.tab-btn {
+  padding: 8px 16px;
+  background-color: var(--card-background);
+  color: var(--text-color);
+  border: 1px solid var(--primary-color);
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 14px;
+  transition: all 0.2s;
+}
+
+.tab-btn:hover {
+  background-color: var(--border-color);
+}
+
+.tab-btn.active {
+  background-color: var(--primary-color);
+  color: white;
+}
+
+@media (max-width: 480px) {
+  .tab-buttons {
+    gap: 4px;
+  }
+
+  .tab-btn {
+    padding: 6px 12px;
+    font-size: 12px;
+    flex: 1;
+    text-align: center;
+  }
+}
+
+/* Game card responsive */
+@media (max-width: 480px) {
+  .game-card .score {
+    font-size: 22px;
+  }
+
+  .game-card .team-name {
+    font-size: 12px;
+  }
+
+  .game-card .vs {
+    padding: 0 8px;
+  }
+}
+
+/* Stat card responsive */
+@media (max-width: 480px) {
+  .stat-card .stat-value {
+    font-size: 22px;
+  }
+
+  .stat-card .stat-label {
+    font-size: 10px;
+  }
 }

--- a/frontend/src/pages/AccountPage.css
+++ b/frontend/src/pages/AccountPage.css
@@ -183,3 +183,86 @@
   border-radius: 4px;
   margin-bottom: 16px;
 }
+
+/* Responsive styles */
+@media (max-width: 768px) {
+  .account-page {
+    padding: 12px;
+  }
+
+  .account-profile {
+    flex-direction: column;
+    text-align: center;
+  }
+
+  .account-info h1 {
+    font-size: 20px;
+  }
+
+  .favorites-tabs {
+    gap: 0;
+  }
+
+  .favorites-tabs .tab-button {
+    padding: 10px 16px;
+    font-size: 14px;
+    flex: 1;
+    text-align: center;
+  }
+
+  .favorites-content {
+    padding: 16px;
+  }
+
+  .favorites-grid {
+    grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+    gap: 12px;
+  }
+
+  .favorite-card {
+    padding: 16px;
+  }
+
+  .favorite-logo,
+  .favorite-headshot,
+  .favorite-number {
+    width: 48px;
+    height: 48px;
+  }
+
+  .favorite-number {
+    font-size: 16px;
+  }
+
+  .favorite-abbrev {
+    font-size: 24px;
+  }
+
+  .favorite-name {
+    font-size: 14px;
+  }
+
+  .favorite-meta {
+    font-size: 12px;
+  }
+
+  .empty-state {
+    padding: 32px 16px;
+  }
+}
+
+@media (max-width: 480px) {
+  .account-avatar {
+    width: 48px;
+    height: 48px;
+  }
+
+  .favorites-grid {
+    grid-template-columns: 1fr 1fr;
+    gap: 8px;
+  }
+
+  .favorite-card {
+    padding: 12px;
+  }
+}

--- a/frontend/src/pages/AdminPage.css
+++ b/frontend/src/pages/AdminPage.css
@@ -173,3 +173,62 @@
   background: rgba(191, 13, 62, 0.1);
   border-radius: 4px;
 }
+
+/* Responsive styles */
+@media (max-width: 768px) {
+  .admin-page {
+    padding: 12px;
+  }
+
+  .admin-page h1 {
+    font-size: 20px;
+    margin-bottom: 16px;
+  }
+
+  .admin-tabs {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .tab-button {
+    padding: 10px 16px;
+    font-size: 14px;
+    white-space: nowrap;
+  }
+
+  .tab-content {
+    padding: 16px;
+  }
+
+  .sync-buttons {
+    flex-direction: column;
+  }
+
+  .sync-button {
+    width: 100%;
+    justify-content: center;
+  }
+
+  /* Users table responsive */
+  .users-table-wrapper {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .users-table {
+    min-width: 500px;
+  }
+
+  .users-table th,
+  .users-table td {
+    padding: 8px;
+    font-size: 13px;
+  }
+}
+
+@media (max-width: 480px) {
+  .tab-button {
+    padding: 8px 12px;
+    font-size: 13px;
+  }
+}

--- a/frontend/src/pages/LoginPage.css
+++ b/frontend/src/pages/LoginPage.css
@@ -7,7 +7,7 @@
 }
 
 .login-card {
-  background: white;
+  background: var(--card-background);
   border-radius: 8px;
   box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
   padding: 40px;
@@ -17,7 +17,7 @@
 }
 
 .login-card h1 {
-  color: #002d72;
+  color: var(--primary-color);
   margin-bottom: 8px;
 }
 
@@ -57,4 +57,24 @@
 
 .google-login-btn svg {
   flex-shrink: 0;
+}
+
+/* Responsive styles */
+@media (max-width: 480px) {
+  .login-page {
+    padding: 16px;
+  }
+
+  .login-card {
+    padding: 24px;
+  }
+
+  .login-card h1 {
+    font-size: 24px;
+  }
+
+  .google-login-btn {
+    padding: 10px 16px;
+    font-size: 14px;
+  }
 }

--- a/frontend/src/pages/PlayerDetailPage.tsx
+++ b/frontend/src/pages/PlayerDetailPage.tsx
@@ -55,40 +55,21 @@ function PlayerDetailPage() {
   return (
     <div>
       <div className="card" style={{ marginBottom: '24px' }}>
-        <div style={{ display: 'flex', alignItems: 'flex-start', gap: '24px' }}>
+        <div className="detail-header">
           {player.headshotUrl ? (
             <img
               src={player.headshotUrl}
               alt={player.fullName}
-              style={{
-                width: '100px',
-                height: '100px',
-                borderRadius: '50%',
-                objectFit: 'cover',
-                flexShrink: 0,
-                backgroundColor: 'var(--border-color)',
-              }}
+              className="detail-header-image"
             />
           ) : (
-            <div style={{
-              width: '100px',
-              height: '100px',
-              backgroundColor: 'var(--primary-color)',
-              color: 'white',
-              borderRadius: '50%',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              fontSize: '32px',
-              fontWeight: 'bold',
-              flexShrink: 0,
-            }}>
+            <div className="detail-header-placeholder">
               {player.jerseyNumber || '?'}
             </div>
           )}
-          <div style={{ flex: 1 }}>
-            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '16px' }}>
-              <h1 style={{ margin: 0, fontSize: '28px' }}>{player.fullName}</h1>
+          <div className="detail-header-content">
+            <div className="detail-header-title">
+              <h1>{player.fullName}</h1>
               <FavoriteButton
                 isFavorite={isFavorite}
                 loading={favoriteLoading}
@@ -115,22 +96,22 @@ function PlayerDetailPage() {
               )}
             </div>
 
-            <div style={{ marginTop: '16px', display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: '16px' }}>
-              <div>
-                <div style={{ fontSize: '12px', color: 'var(--text-light)', textTransform: 'uppercase' }}>Bats/Throws</div>
-                <div style={{ fontWeight: '600' }}>{player.bats || '-'}/{player.throwsHand || '-'}</div>
+            <div className="detail-stats-grid">
+              <div className="detail-stat-item">
+                <div className="detail-stat-label">Bats/Throws</div>
+                <div className="detail-stat-value">{player.bats || '-'}/{player.throwsHand || '-'}</div>
               </div>
-              <div>
-                <div style={{ fontSize: '12px', color: 'var(--text-light)', textTransform: 'uppercase' }}>Height/Weight</div>
-                <div style={{ fontWeight: '600' }}>{player.height || '-'} / {player.weight || '-'} lbs</div>
+              <div className="detail-stat-item">
+                <div className="detail-stat-label">Height/Weight</div>
+                <div className="detail-stat-value">{player.height || '-'} / {player.weight || '-'} lbs</div>
               </div>
-              <div>
-                <div style={{ fontSize: '12px', color: 'var(--text-light)', textTransform: 'uppercase' }}>Birth Date</div>
-                <div style={{ fontWeight: '600' }}>{formatDate(player.birthDate)}</div>
+              <div className="detail-stat-item">
+                <div className="detail-stat-label">Birth Date</div>
+                <div className="detail-stat-value">{formatDate(player.birthDate)}</div>
               </div>
-              <div>
-                <div style={{ fontSize: '12px', color: 'var(--text-light)', textTransform: 'uppercase' }}>MLB Debut</div>
-                <div style={{ fontWeight: '600' }}>{formatDate(player.mlbDebutDate)}</div>
+              <div className="detail-stat-item">
+                <div className="detail-stat-label">MLB Debut</div>
+                <div className="detail-stat-value">{formatDate(player.mlbDebutDate)}</div>
               </div>
             </div>
           </div>

--- a/frontend/src/pages/PlayersPage.tsx
+++ b/frontend/src/pages/PlayersPage.tsx
@@ -42,26 +42,16 @@ function PlayersPage() {
     <div>
       <h1 className="page-title">MLB Players</h1>
 
-      <form onSubmit={handleSearch} style={{ marginBottom: '20px' }}>
+      <form onSubmit={handleSearch} className="search-form" style={{ marginBottom: '20px', display: 'flex', flexWrap: 'wrap', gap: '8px' }}>
         <input
           type="text"
           className="search-input"
           placeholder="Search players by name..."
           value={searchInput}
           onChange={(e) => setSearchInput(e.target.value)}
+          style={{ marginBottom: 0 }}
         />
-        <button
-          type="submit"
-          style={{
-            padding: '12px 24px',
-            marginLeft: '8px',
-            backgroundColor: '#002d72',
-            color: 'white',
-            border: 'none',
-            borderRadius: '8px',
-            cursor: 'pointer',
-          }}
-        >
+        <button type="submit" className="tab-btn active">
           Search
         </button>
       </form>

--- a/frontend/src/pages/TeamDetailPage.tsx
+++ b/frontend/src/pages/TeamDetailPage.tsx
@@ -54,72 +54,51 @@ function TeamDetailPage() {
   return (
     <div>
       <div className="card" style={{ marginBottom: '24px' }}>
-        <div style={{ display: 'flex', alignItems: 'center', gap: '16px' }}>
+        <div className="detail-header">
           {team.logoUrl ? (
             <img
               src={team.logoUrl}
               alt={`${team.name} logo`}
-              style={{ width: '80px', height: '80px', objectFit: 'contain' }}
+              className="team-detail-logo"
             />
           ) : (
-            <div style={{ fontSize: '48px', fontWeight: 'bold', color: 'var(--primary-color)' }}>
+            <div className="team-detail-abbrev">
               {team.abbreviation}
             </div>
           )}
-          <div style={{ flex: 1 }}>
-            <h1 style={{ margin: 0, fontSize: '28px' }}>{team.name}</h1>
+          <div className="detail-header-content">
+            <div className="detail-header-title">
+              <h1>{team.name}</h1>
+              <FavoriteButton
+                isFavorite={isFavorite}
+                loading={favoriteLoading}
+                toggling={toggling}
+                onToggle={toggleFavorite}
+              />
+            </div>
             <p style={{ margin: '4px 0 0', color: 'var(--text-light)' }}>
               {team.league} - {team.division} | {team.venueName}
             </p>
           </div>
-          <FavoriteButton
-            isFavorite={isFavorite}
-            loading={favoriteLoading}
-            toggling={toggling}
-            onToggle={toggleFavorite}
-          />
         </div>
       </div>
 
-      <div style={{ marginBottom: '16px' }}>
+      <div className="tab-buttons">
         <button
           onClick={() => setActiveTab('roster')}
-          style={{
-            padding: '8px 16px',
-            marginRight: '8px',
-            backgroundColor: activeTab === 'roster' ? '#002d72' : '#fff',
-            color: activeTab === 'roster' ? '#fff' : '#333',
-            border: '1px solid #002d72',
-            borderRadius: '4px',
-            cursor: 'pointer',
-          }}
+          className={`tab-btn ${activeTab === 'roster' ? 'active' : ''}`}
         >
           Roster ({roster.length})
         </button>
         <button
           onClick={() => setActiveTab('stats')}
-          style={{
-            padding: '8px 16px',
-            marginRight: '8px',
-            backgroundColor: activeTab === 'stats' ? '#002d72' : '#fff',
-            color: activeTab === 'stats' ? '#fff' : '#333',
-            border: '1px solid #002d72',
-            borderRadius: '4px',
-            cursor: 'pointer',
-          }}
+          className={`tab-btn ${activeTab === 'stats' ? 'active' : ''}`}
         >
           Stats
         </button>
         <button
           onClick={() => setActiveTab('games')}
-          style={{
-            padding: '8px 16px',
-            backgroundColor: activeTab === 'games' ? '#002d72' : '#fff',
-            color: activeTab === 'games' ? '#fff' : '#333',
-            border: '1px solid #002d72',
-            borderRadius: '4px',
-            cursor: 'pointer',
-          }}
+          className={`tab-btn ${activeTab === 'games' ? 'active' : ''}`}
         >
           Games ({games.length})
         </button>


### PR DESCRIPTION
## Summary

Makes the site responsive for mobile, tablet, and desktop devices with comprehensive media queries and CSS updates.

## Breakpoints

- **Desktop**: > 992px (default)
- **Tablet**: 768px - 992px
- **Mobile**: 480px - 768px
- **Small mobile**: < 480px

## Changes

### Global (index.css)
- Added responsive breakpoints for grids, cards, and page content
- New CSS classes for detail page headers that stack vertically on mobile
- Tab button styles that adapt to screen size
- Stats grid that changes from 4 to 2 columns on smaller screens

### Header
- Hide username on mobile (keep avatar)
- Reduce button padding on smaller screens

### Navigation
- Horizontal scroll on mobile instead of line wrapping
- Smaller font and padding

### Tables
- Added `.table-responsive` wrapper class for horizontal scroll

### Detail Pages
- Player/team headers stack vertically on mobile
- Centered layout with smaller images
- Stats grid adapts to 2 columns

### Account Page
- Profile stacks vertically on mobile
- Favorites grid becomes 2 columns on small screens
- Smaller images and cards

### Admin Page
- Sync buttons stack vertically on mobile
- Table wrapper for horizontal scroll
- Smaller tab buttons

### Login Page
- Reduced card padding on mobile
- Theme variable usage for dark mode

### Players Page
- Search form wraps on mobile

## Test plan

- [ ] Test on desktop (> 992px) - normal layout
- [ ] Test on tablet (~768px) - grids should be 2 columns
- [ ] Test on mobile (~480px) - single column, stacked headers
- [ ] Test navigation scrolls horizontally on mobile
- [ ] Test tables scroll horizontally on mobile
- [ ] Test in dark mode at all breakpoints
- [ ] Test login page on mobile

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)