### PR TITLE
Add season data management for admins

### DIFF
--- a/backend/src/main/java/com/mlbstats/api/controller/DataManagerController.java
+++ b/backend/src/main/java/com/mlbstats/api/controller/DataManagerController.java
@@ -1,0 +1,42 @@
+package com.mlbstats.api.controller;
+
+import com.mlbstats.api.dto.SeasonDataDto;
+import com.mlbstats.api.service.DataManagerService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/data-manager")
+@Tag(name = "Data Manager", description = "Season data management APIs")
+@PreAuthorize("hasRole('ADMIN')")
+@RequiredArgsConstructor
+public class DataManagerController {
+
+    private final DataManagerService dataManagerService;
+
+    @GetMapping("/seasons")
+    @Operation(summary = "Get synced seasons", description = "Returns all seasons with synced data and their metrics")
+    public ResponseEntity<List<SeasonDataDto>> getSyncedSeasons() {
+        return ResponseEntity.ok(dataManagerService.getSyncedSeasons());
+    }
+
+    @GetMapping("/seasons/available")
+    @Operation(summary = "Get available seasons", description = "Returns seasons available for syncing")
+    public ResponseEntity<List<Integer>> getAvailableSeasons() {
+        return ResponseEntity.ok(dataManagerService.getAvailableSeasons());
+    }
+
+    @DeleteMapping("/seasons/{season}")
+    @Operation(summary = "Delete season data", description = "Deletes all data for a specific season")
+    public ResponseEntity<Map<String, String>> deleteSeasonData(@PathVariable Integer season) {
+        dataManagerService.deleteSeasonData(season);
+        return ResponseEntity.ok(Map.of("status", "deleted", "season", String.valueOf(season)));
+    }
+}

--- a/backend/src/main/java/com/mlbstats/api/dto/SeasonDataDto.java
+++ b/backend/src/main/java/com/mlbstats/api/dto/SeasonDataDto.java
@@ -1,0 +1,12 @@
+package com.mlbstats.api.dto;
+
+public record SeasonDataDto(
+        Integer season,
+        long gamesCount,
+        long battingStatsCount,
+        long pitchingStatsCount,
+        long rosterEntriesCount,
+        long standingsCount,
+        boolean isCurrent
+) {
+}

--- a/backend/src/main/java/com/mlbstats/api/service/DataManagerService.java
+++ b/backend/src/main/java/com/mlbstats/api/service/DataManagerService.java
@@ -1,0 +1,80 @@
+package com.mlbstats.api.service;
+
+import com.mlbstats.api.dto.SeasonDataDto;
+import com.mlbstats.common.util.DateUtils;
+import com.mlbstats.domain.game.GameRepository;
+import com.mlbstats.domain.player.TeamRosterRepository;
+import com.mlbstats.domain.stats.PlayerBattingStatsRepository;
+import com.mlbstats.domain.stats.PlayerPitchingStatsRepository;
+import com.mlbstats.domain.team.TeamStandingRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DataManagerService {
+
+    private final GameRepository gameRepository;
+    private final PlayerBattingStatsRepository battingStatsRepository;
+    private final PlayerPitchingStatsRepository pitchingStatsRepository;
+    private final TeamRosterRepository rosterRepository;
+    private final TeamStandingRepository standingRepository;
+
+    public List<SeasonDataDto> getSyncedSeasons() {
+        // Collect all distinct seasons from all tables
+        Set<Integer> allSeasons = new HashSet<>();
+        allSeasons.addAll(gameRepository.findDistinctSeasons());
+        allSeasons.addAll(standingRepository.findDistinctSeasons());
+
+        int currentSeason = DateUtils.getCurrentSeason();
+
+        return allSeasons.stream()
+                .sorted((a, b) -> b - a) // Descending order
+                .map(season -> new SeasonDataDto(
+                        season,
+                        gameRepository.countBySeason(season),
+                        battingStatsRepository.countBySeason(season),
+                        pitchingStatsRepository.countBySeason(season),
+                        rosterRepository.countBySeason(season),
+                        standingRepository.countBySeason(season),
+                        season == currentSeason
+                ))
+                .collect(Collectors.toList());
+    }
+
+    public List<Integer> getAvailableSeasons() {
+        // Return seasons that can be synced (current year and previous 10 years)
+        int currentYear = java.time.Year.now().getValue();
+        return java.util.stream.IntStream.rangeClosed(currentYear - 10, currentYear)
+                .boxed()
+                .sorted((a, b) -> b - a)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public void deleteSeasonData(Integer season) {
+        int currentSeason = DateUtils.getCurrentSeason();
+        if (season == currentSeason) {
+            throw new IllegalArgumentException("Cannot delete current season data");
+        }
+
+        log.info("Deleting all data for season {}", season);
+
+        // Delete in order to respect foreign key constraints
+        standingRepository.deleteBySeason(season);
+        pitchingStatsRepository.deleteBySeason(season);
+        battingStatsRepository.deleteBySeason(season);
+        rosterRepository.deleteBySeason(season);
+        gameRepository.deleteBySeason(season);
+
+        log.info("Successfully deleted all data for season {}", season);
+    }
+}

--- a/backend/src/main/java/com/mlbstats/domain/game/GameRepository.java
+++ b/backend/src/main/java/com/mlbstats/domain/game/GameRepository.java
@@ -40,4 +40,11 @@ public interface GameRepository extends JpaRepository<Game, Long> {
     Optional<Game> findByIdWithTeams(@Param("id") Long id);
 
     boolean existsByMlbId(Integer mlbId);
+
+    @Query("SELECT DISTINCT g.season FROM Game g ORDER BY g.season DESC")
+    List<Integer> findDistinctSeasons();
+
+    long countBySeason(Integer season);
+
+    void deleteBySeason(Integer season);
 }

--- a/backend/src/main/java/com/mlbstats/domain/player/TeamRosterRepository.java
+++ b/backend/src/main/java/com/mlbstats/domain/player/TeamRosterRepository.java
@@ -26,4 +26,8 @@ public interface TeamRosterRepository extends JpaRepository<TeamRoster, Long> {
             Long teamId, Long playerId, Integer season, LocalDate startDate);
 
     boolean existsByTeamIdAndPlayerIdAndSeason(Long teamId, Long playerId, Integer season);
+
+    long countBySeason(Integer season);
+
+    void deleteBySeason(Integer season);
 }

--- a/backend/src/main/java/com/mlbstats/domain/stats/PlayerBattingStatsRepository.java
+++ b/backend/src/main/java/com/mlbstats/domain/stats/PlayerBattingStatsRepository.java
@@ -28,4 +28,8 @@ public interface PlayerBattingStatsRepository extends JpaRepository<PlayerBattin
 
     @Query("SELECT pbs FROM PlayerBattingStats pbs JOIN FETCH pbs.player JOIN FETCH pbs.team WHERE pbs.season = :season AND pbs.atBats >= :minAtBats ORDER BY pbs.battingAvg DESC")
     List<PlayerBattingStats> findTopBattingAverage(@Param("season") Integer season, @Param("minAtBats") Integer minAtBats);
+
+    long countBySeason(Integer season);
+
+    void deleteBySeason(Integer season);
 }

--- a/backend/src/main/java/com/mlbstats/domain/stats/PlayerPitchingStatsRepository.java
+++ b/backend/src/main/java/com/mlbstats/domain/stats/PlayerPitchingStatsRepository.java
@@ -32,4 +32,8 @@ public interface PlayerPitchingStatsRepository extends JpaRepository<PlayerPitch
 
     @Query("SELECT pps FROM PlayerPitchingStats pps JOIN FETCH pps.player JOIN FETCH pps.team WHERE pps.season = :season ORDER BY pps.strikeouts DESC")
     List<PlayerPitchingStats> findTopStrikeouts(@Param("season") Integer season);
+
+    long countBySeason(Integer season);
+
+    void deleteBySeason(Integer season);
 }

--- a/backend/src/main/java/com/mlbstats/domain/team/TeamStandingRepository.java
+++ b/backend/src/main/java/com/mlbstats/domain/team/TeamStandingRepository.java
@@ -20,4 +20,8 @@ public interface TeamStandingRepository extends JpaRepository<TeamStanding, Long
 
     @Query("SELECT DISTINCT ts.season FROM TeamStanding ts ORDER BY ts.season DESC")
     List<Integer> findDistinctSeasons();
+
+    long countBySeason(Integer season);
+
+    void deleteBySeason(Integer season);
 }

--- a/frontend/src/pages/AdminPage.css
+++ b/frontend/src/pages/AdminPage.css
@@ -174,6 +174,115 @@
   border-radius: 4px;
 }
 
+/* Data Manager Panel */
+.data-panel h2 {
+  margin-bottom: 8px;
+  color: var(--text-color);
+}
+
+.data-panel h3 {
+  margin-top: 24px;
+  margin-bottom: 16px;
+  color: var(--text-color);
+  font-size: 16px;
+}
+
+.seasons-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 24px;
+}
+
+.seasons-table th,
+.seasons-table td {
+  padding: 12px;
+  text-align: left;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.seasons-table th {
+  background: var(--primary-color);
+  color: white;
+  font-weight: 600;
+}
+
+.seasons-table tr:hover {
+  background: var(--border-color);
+}
+
+.current-badge {
+  display: inline-block;
+  margin-left: 8px;
+  padding: 2px 8px;
+  font-size: 11px;
+  font-weight: 600;
+  background: var(--success-color);
+  color: white;
+  border-radius: 4px;
+  text-transform: uppercase;
+}
+
+.sync-button.small {
+  padding: 6px 12px;
+  font-size: 12px;
+}
+
+.delete-button {
+  padding: 6px 12px;
+  margin-left: 8px;
+  border: 2px solid var(--secondary-color);
+  background: var(--card-background);
+  color: var(--secondary-color);
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 500;
+  transition: all 0.2s;
+}
+
+.delete-button:hover {
+  background: var(--secondary-color);
+  color: white;
+}
+
+.delete-button.confirm {
+  background: var(--secondary-color);
+  color: white;
+}
+
+.cancel-button {
+  padding: 6px 12px;
+  margin-left: 8px;
+  border: 2px solid var(--border-color);
+  background: var(--card-background);
+  color: var(--text-light);
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 500;
+  transition: all 0.2s;
+}
+
+.cancel-button:hover {
+  background: var(--border-color);
+}
+
+.sync-new-season {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+.sync-new-season select {
+  padding: 12px 16px;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  font-size: 14px;
+  background: var(--card-background);
+  color: var(--text-color);
+  min-width: 200px;
+}
+
 /* Responsive styles */
 @media (max-width: 768px) {
   .admin-page {
@@ -230,5 +339,30 @@
   .tab-button {
     padding: 8px 12px;
     font-size: 13px;
+  }
+}
+
+/* Seasons table responsive */
+@media (max-width: 992px) {
+  .seasons-table {
+    display: block;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+}
+
+@media (max-width: 768px) {
+  .sync-new-season {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .sync-new-season select {
+    width: 100%;
+  }
+
+  .sync-new-season .sync-button {
+    width: 100%;
+    justify-content: center;
   }
 }

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -177,6 +177,42 @@ export async function triggerStandingsSync(season?: number): Promise<{ status: s
   return postJson(`${API_BASE}/ingestion/standings${params}`);
 }
 
+// Data Manager
+export interface SeasonData {
+  season: number;
+  gamesCount: number;
+  battingStatsCount: number;
+  pitchingStatsCount: number;
+  rosterEntriesCount: number;
+  standingsCount: number;
+  isCurrent: boolean;
+}
+
+export async function getSyncedSeasons(): Promise<SeasonData[]> {
+  return fetchJson<SeasonData[]>(`${API_BASE}/data-manager/seasons`);
+}
+
+export async function getAvailableSeasons(): Promise<number[]> {
+  return fetchJson<number[]>(`${API_BASE}/data-manager/seasons/available`);
+}
+
+export async function deleteSeasonData(season: number): Promise<{ status: string }> {
+  const csrfToken = getCsrfToken();
+  const headers: HeadersInit = {};
+  if (csrfToken) {
+    headers['X-XSRF-TOKEN'] = csrfToken;
+  }
+  const response = await fetch(`${API_BASE}/data-manager/seasons/${season}`, {
+    method: 'DELETE',
+    credentials: 'include',
+    headers,
+  });
+  if (!response.ok) {
+    throw new Error(`API error: ${response.status}`);
+  }
+  return response.json();
+}
+
 // Admin - User Management
 export interface AdminUser {
   id: number;


### PR DESCRIPTION
## Summary
Adds a Data Manager tab to the Admin page that allows admins to:
- View all synced seasons with metrics (games, batting stats, pitching stats, roster entries, standings)
- Sync new seasons from a dropdown of available years (last 10 years)
- Re-sync existing seasons to refresh data
- Delete non-current season data (with confirmation)

### Backend Changes
- New `DataManagerController` with endpoints:
  - `GET /api/data-manager/seasons` - list synced seasons with counts
  - `GET /api/data-manager/seasons/available` - list available years for syncing
  - `DELETE /api/data-manager/seasons/{season}` - delete all data for a season
- New `DataManagerService` to aggregate season statistics
- New `SeasonDataDto` record for season metrics
- Added `countBySeason()` and `deleteBySeason()` to all season-based repositories

### Frontend Changes
- New "Data Manager" tab in Admin page
- Seasons table showing metrics for each synced season
- "Current" badge for the current season
- Sync/Re-sync and Delete buttons with confirmation
- Dropdown to sync new seasons

## Test plan
- [ ] Navigate to Admin > Data Manager tab
- [ ] Verify synced seasons are displayed with correct counts
- [ ] Select an available season and click "Sync Season"
- [ ] Verify the new season appears in the table after sync
- [ ] Click "Re-sync" on an existing season
- [ ] Try to delete a non-current season (should show confirmation)
- [ ] Verify current season cannot be deleted

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)