### PR TITLE
Add Datadog application monitoring integration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,3 +158,41 @@ Add GA4 events for:
 - Measurement ID is set via `VITE_GA_MEASUREMENT_ID` env var
 - Local development: set in `frontend/.env`
 - Production: configured via Terraform (`ga_measurement_id` variable)
+
+## Datadog Application Monitoring
+
+The backend integrates with Datadog for application monitoring and metrics via Spring Boot Actuator and Micrometer.
+
+### Metrics Exported
+
+- HTTP request metrics (latency, status codes, throughput)
+- JVM metrics (heap, GC, threads)
+- Database connection pool metrics
+- Custom application metrics
+
+### Configuration
+
+Enable Datadog monitoring via environment variables:
+
+| Variable | Description |
+|----------|-------------|
+| `DATADOG_ENABLED` | Set to `true` to enable metrics export |
+| `DATADOG_API_KEY` | Datadog API key |
+| `DATADOG_APP_KEY` | Datadog Application key |
+| `ENVIRONMENT` | Environment tag (e.g., `production`, `staging`) |
+
+### Terraform Setup
+
+```hcl
+datadog_enabled = true
+datadog_api_key = "your-api-key"
+datadog_app_key = "your-app-key"
+```
+
+### Actuator Endpoints
+
+Available at `/actuator/*` (requires authentication):
+- `/actuator/health` - Application health status
+- `/actuator/info` - Application info
+- `/actuator/metrics` - Available metrics list
+- `/actuator/metrics/{name}` - Specific metric details

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -54,6 +54,10 @@
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-datadog</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-thymeleaf</artifactId>
         </dependency>

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -80,12 +80,28 @@ springdoc:
     enabled: ${SWAGGER_ENABLED:false}
     path: /swagger-ui.html
 
-# Actuator
+# Actuator & Metrics
 management:
   endpoints:
     web:
       exposure:
-        include: health
+        include: health,info,metrics,prometheus
   endpoint:
     health:
-      show-details: never
+      show-details: when_authorized
+  metrics:
+    tags:
+      application: ${spring.application.name}
+      environment: ${ENVIRONMENT:production}
+    distribution:
+      percentiles-histogram:
+        http.server.requests: true
+  datadog:
+    metrics:
+      export:
+        enabled: ${DATADOG_ENABLED:false}
+        api-key: ${DATADOG_API_KEY:}
+        application-key: ${DATADOG_APP_KEY:}
+        uri: https://api.datadoghq.com
+        step: 30s
+        descriptions: true

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -153,6 +153,30 @@ resource "digitalocean_app" "mlb_stats" {
         scope = "BUILD_TIME"
         type  = "GENERAL"
       }
+
+      env {
+        key   = "DATADOG_ENABLED"
+        value = var.datadog_enabled ? "true" : "false"
+        type  = "GENERAL"
+      }
+
+      env {
+        key   = "DATADOG_API_KEY"
+        value = var.datadog_api_key
+        type  = "SECRET"
+      }
+
+      env {
+        key   = "DATADOG_APP_KEY"
+        value = var.datadog_app_key
+        type  = "SECRET"
+      }
+
+      env {
+        key   = "ENVIRONMENT"
+        value = "production"
+        type  = "GENERAL"
+      }
     }
   }
 }

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -35,6 +35,12 @@ ga_measurement_id = "G-XXXXXXXXXX"
 # Custom Domain (optional - for DO-managed domains, CNAME record is created automatically)
 # custom_domain = "stats.yourdomain.com"
 
+# Datadog Monitoring (optional)
+# Get API/App keys from: https://app.datadoghq.com/organization-settings/api-keys
+# datadog_enabled = true
+# datadog_api_key = "your-datadog-api-key"
+# datadog_app_key = "your-datadog-app-key"
+
 # Optional: Override defaults
 # app_name       = "mlb-stats"
 # region         = "nyc"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -105,3 +105,24 @@ variable "custom_domain" {
   type        = string
   default     = ""
 }
+
+# Datadog Monitoring
+variable "datadog_enabled" {
+  description = "Enable Datadog metrics export"
+  type        = bool
+  default     = false
+}
+
+variable "datadog_api_key" {
+  description = "Datadog API key"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "datadog_app_key" {
+  description = "Datadog Application key"
+  type        = string
+  sensitive   = true
+  default     = ""
+}


### PR DESCRIPTION
## Summary
Integrates the application with Datadog for application monitoring and metrics collection using Spring Boot Actuator and Micrometer.

### Features
- **Metrics Export**: HTTP request latency, status codes, JVM metrics, database pool metrics
- **Conditional Enable**: Only exports metrics when `DATADOG_ENABLED=true`
- **Environment Tagging**: Metrics tagged with application name and environment
- **30-second Export Interval**: Configurable via `step` property

### Changes
- Add `micrometer-registry-datadog` dependency to pom.xml
- Update `application.yml` with Datadog and Actuator configuration
- Add Terraform variables: `datadog_enabled`, `datadog_api_key`, `datadog_app_key`
- Add environment variables to Digital Ocean app deployment
- Update `terraform.tfvars.example` with Datadog configuration
- Update `CLAUDE.md` with monitoring documentation

### Configuration
```hcl
# In terraform.tfvars
datadog_enabled = true
datadog_api_key = "your-api-key"
datadog_app_key = "your-app-key"
```

## Test plan
- [ ] Deploy with Datadog disabled (default) - verify app starts normally
- [ ] Enable Datadog with valid API keys
- [ ] Verify metrics appear in Datadog dashboard
- [ ] Check `/actuator/health` endpoint works
- [ ] Check `/actuator/metrics` lists available metrics

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)