### PR TITLE
Add New Relic application monitoring integration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,3 +158,47 @@ Add GA4 events for:
 - Measurement ID is set via `VITE_GA_MEASUREMENT_ID` env var
 - Local development: set in `frontend/.env`
 - Production: configured via Terraform (`ga_measurement_id` variable)
+
+## New Relic Application Monitoring
+
+The backend integrates with New Relic for application monitoring and metrics via Spring Boot Actuator and Micrometer.
+
+### Metrics Exported
+
+- HTTP request metrics (latency, status codes, throughput)
+- JVM metrics (heap, GC, threads)
+- Database connection pool metrics
+- Custom application metrics
+
+### Configuration
+
+Enable New Relic monitoring via environment variables:
+
+| Variable | Description |
+|----------|-------------|
+| `NEW_RELIC_ENABLED` | Set to `true` to enable metrics export |
+| `NEW_RELIC_API_KEY` | New Relic Ingest License key |
+| `NEW_RELIC_ACCOUNT_ID` | New Relic Account ID |
+| `ENVIRONMENT` | Environment tag (e.g., `production`, `staging`) |
+
+### Terraform Setup
+
+```hcl
+new_relic_enabled    = true
+new_relic_api_key    = "your-license-key"
+new_relic_account_id = "your-account-id"
+```
+
+### Getting New Relic Credentials
+
+1. Sign up at https://newrelic.com (free tier available)
+2. Get License Key: User menu > API Keys > Create key (Ingest - License)
+3. Get Account ID: User menu > Administration > Access management
+
+### Actuator Endpoints
+
+Available at `/actuator/*` (requires authentication):
+- `/actuator/health` - Application health status
+- `/actuator/info` - Application info
+- `/actuator/metrics` - Available metrics list
+- `/actuator/metrics/{name}` - Specific metric details

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -54,6 +54,10 @@
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-new-relic</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-thymeleaf</artifactId>
         </dependency>

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -80,12 +80,27 @@ springdoc:
     enabled: ${SWAGGER_ENABLED:false}
     path: /swagger-ui.html
 
-# Actuator
+# Actuator & Metrics
 management:
   endpoints:
     web:
       exposure:
-        include: health
+        include: health,info,metrics
   endpoint:
     health:
-      show-details: never
+      show-details: when_authorized
+  metrics:
+    tags:
+      application: ${spring.application.name}
+      environment: ${ENVIRONMENT:production}
+    distribution:
+      percentiles-histogram:
+        http.server.requests: true
+  newrelic:
+    metrics:
+      export:
+        enabled: ${NEW_RELIC_ENABLED:false}
+        api-key: ${NEW_RELIC_API_KEY:}
+        account-id: ${NEW_RELIC_ACCOUNT_ID:}
+        uri: https://metric-api.newrelic.com
+        step: 30s

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -153,6 +153,30 @@ resource "digitalocean_app" "mlb_stats" {
         scope = "BUILD_TIME"
         type  = "GENERAL"
       }
+
+      env {
+        key   = "NEW_RELIC_ENABLED"
+        value = var.new_relic_enabled ? "true" : "false"
+        type  = "GENERAL"
+      }
+
+      env {
+        key   = "NEW_RELIC_API_KEY"
+        value = var.new_relic_api_key
+        type  = "SECRET"
+      }
+
+      env {
+        key   = "NEW_RELIC_ACCOUNT_ID"
+        value = var.new_relic_account_id
+        type  = "GENERAL"
+      }
+
+      env {
+        key   = "ENVIRONMENT"
+        value = "production"
+        type  = "GENERAL"
+      }
     }
   }
 }

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -35,6 +35,13 @@ ga_measurement_id = "G-XXXXXXXXXX"
 # Custom Domain (optional - for DO-managed domains, CNAME record is created automatically)
 # custom_domain = "stats.yourdomain.com"
 
+# New Relic Monitoring (optional)
+# Get API key from: https://one.newrelic.com/api-keys (Ingest - License key)
+# Get Account ID from: https://one.newrelic.com (User menu > Administration > Access management)
+# new_relic_enabled    = true
+# new_relic_api_key    = "your-new-relic-license-key"
+# new_relic_account_id = "your-account-id"
+
 # Optional: Override defaults
 # app_name       = "mlb-stats"
 # region         = "nyc"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -105,3 +105,23 @@ variable "custom_domain" {
   type        = string
   default     = ""
 }
+
+# New Relic Monitoring
+variable "new_relic_enabled" {
+  description = "Enable New Relic metrics export"
+  type        = bool
+  default     = false
+}
+
+variable "new_relic_api_key" {
+  description = "New Relic Ingest API key (License key)"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "new_relic_account_id" {
+  description = "New Relic Account ID"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
## Summary

- Integrates New Relic for application performance monitoring via Spring Boot Actuator and Micrometer
- Exports HTTP request metrics (latency, status codes, throughput), JVM metrics, and database connection pool metrics
- Configurable via Terraform variables (`new_relic_enabled`, `new_relic_api_key`, `new_relic_account_id`)
- Disabled by default; enable by setting `new_relic_enabled = true` in terraform.tfvars

Closes #60

## Test plan

- [ ] Verify backend compiles with `./mvnw compile`
- [ ] Verify Terraform validates with `terraform validate`
- [ ] Test locally with New Relic credentials to confirm metrics appear in New Relic dashboard
- [ ] Verify actuator endpoints accessible at `/actuator/health`, `/actuator/metrics`
- [ ] Confirm no errors when New Relic is disabled (default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)