### PR TITLE
Fix: Promote existing users to OWNER role on login

### DIFF
--- a/backend/src/main/java/com/mlbstats/common/security/CustomOAuth2UserService.java
+++ b/backend/src/main/java/com/mlbstats/common/security/CustomOAuth2UserService.java
@@ -39,6 +39,12 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         user.setName(name);
         user.setPictureUrl(picture);
         user.recordLogin();
+
+        // Promote to OWNER if email matches configured owner email
+        if (authProperties.isOwnerEmail(user.getEmail()) && user.getRole() != Role.OWNER) {
+            user.setRole(Role.OWNER);
+        }
+
         return appUserRepository.save(user);
     }
 


### PR DESCRIPTION
## Summary

- Fixes issue where existing users weren't promoted to OWNER role even when matching `OWNER_EMAIL`
- Previously, OWNER role was only assigned during initial user creation
- Now, users matching `OWNER_EMAIL` are promoted to OWNER on their next login

## Root Cause

If a user logged in before `OWNER_EMAIL` was configured in the environment, they were created with `USER` role. The `updateExistingUser` method only updated name, picture, and login timestamp - it never checked if the user should be promoted to OWNER.

## Test plan

- [ ] Log in as the configured `OWNER_EMAIL` user in production
- [ ] Verify admin menu is now visible
- [ ] Verify user role shows as OWNER in the database

🤖 Generated with [Claude Code](https://claude.com/claude-code)