### PR TITLE
Add global search functionality

### DIFF
--- a/backend/src/main/java/com/mlbstats/api/controller/SearchController.java
+++ b/backend/src/main/java/com/mlbstats/api/controller/SearchController.java
@@ -1,0 +1,48 @@
+package com.mlbstats.api.controller;
+
+import com.mlbstats.api.dto.PlayerDto;
+import com.mlbstats.api.dto.SearchResultDto;
+import com.mlbstats.api.dto.TeamDto;
+import com.mlbstats.api.service.PlayerApiService;
+import com.mlbstats.api.service.TeamApiService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/search")
+@Tag(name = "Search", description = "Global search APIs")
+@RequiredArgsConstructor
+public class SearchController {
+
+    private final TeamApiService teamApiService;
+    private final PlayerApiService playerApiService;
+
+    private static final int DEFAULT_LIMIT = 5;
+
+    @GetMapping
+    @Operation(summary = "Global search", description = "Search teams and players by name")
+    public ResponseEntity<SearchResultDto> search(
+            @RequestParam String q,
+            @RequestParam(defaultValue = "5") int limit) {
+
+        if (q == null || q.isBlank()) {
+            return ResponseEntity.ok(new SearchResultDto(List.of(), List.of()));
+        }
+
+        String query = q.trim();
+        int effectiveLimit = Math.min(limit, 10);
+
+        List<TeamDto> teams = teamApiService.searchTeams(query).stream()
+                .limit(effectiveLimit)
+                .toList();
+
+        List<PlayerDto> players = playerApiService.searchPlayers(query, effectiveLimit);
+
+        return ResponseEntity.ok(new SearchResultDto(teams, players));
+    }
+}

--- a/backend/src/main/java/com/mlbstats/api/dto/SearchResultDto.java
+++ b/backend/src/main/java/com/mlbstats/api/dto/SearchResultDto.java
@@ -1,0 +1,9 @@
+package com.mlbstats.api.dto;
+
+import java.util.List;
+
+public record SearchResultDto(
+    List<TeamDto> teams,
+    List<PlayerDto> players
+) {
+}

--- a/backend/src/main/java/com/mlbstats/api/service/PlayerApiService.java
+++ b/backend/src/main/java/com/mlbstats/api/service/PlayerApiService.java
@@ -36,6 +36,13 @@ public class PlayerApiService {
         return PageDto.fromPage(page, PlayerDto::fromEntity);
     }
 
+    public List<PlayerDto> searchPlayers(String search, int limit) {
+        return playerRepository.searchPlayersByName(search).stream()
+                .limit(limit)
+                .map(PlayerDto::fromEntity)
+                .toList();
+    }
+
     public PlayerDto getPlayerById(Long id) {
         Player player = playerRepository.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException("Player", id));

--- a/backend/src/main/java/com/mlbstats/api/service/TeamApiService.java
+++ b/backend/src/main/java/com/mlbstats/api/service/TeamApiService.java
@@ -38,6 +38,12 @@ public class TeamApiService {
                 .toList();
     }
 
+    public List<TeamDto> searchTeams(String search) {
+        return teamRepository.searchTeams(search).stream()
+                .map(TeamDto::fromEntity)
+                .toList();
+    }
+
     public List<TeamDto> getTeamsByLeague(String league) {
         return teamRepository.findByLeague(league).stream()
                 .map(TeamDto::fromEntity)

--- a/backend/src/main/java/com/mlbstats/domain/player/PlayerRepository.java
+++ b/backend/src/main/java/com/mlbstats/domain/player/PlayerRepository.java
@@ -29,6 +29,11 @@ public interface PlayerRepository extends JpaRepository<Player, Long> {
            "LOWER(p.position) LIKE LOWER(CONCAT('%', :search, '%')))")
     Page<Player> searchPlayers(@Param("search") String search, Pageable pageable);
 
+    @Query("SELECT p FROM Player p WHERE p.active = true AND " +
+           "LOWER(p.fullName) LIKE LOWER(CONCAT('%', :search, '%')) " +
+           "ORDER BY p.fullName")
+    List<Player> searchPlayersByName(@Param("search") String search);
+
     boolean existsByMlbId(Integer mlbId);
 
     @Query("SELECT p FROM Player p WHERE p.bats IS NULL OR p.height IS NULL OR p.birthDate IS NULL")

--- a/backend/src/main/java/com/mlbstats/domain/team/TeamRepository.java
+++ b/backend/src/main/java/com/mlbstats/domain/team/TeamRepository.java
@@ -2,6 +2,7 @@ package com.mlbstats.domain.team;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -20,6 +21,12 @@ public interface TeamRepository extends JpaRepository<Team, Long> {
 
     @Query("SELECT t FROM Team t ORDER BY t.league, t.division, t.name")
     List<Team> findAllOrderByLeagueAndDivision();
+
+    @Query("SELECT t FROM Team t WHERE LOWER(t.name) LIKE LOWER(CONCAT('%', :search, '%')) " +
+           "OR LOWER(t.abbreviation) LIKE LOWER(CONCAT('%', :search, '%')) " +
+           "OR LOWER(t.locationName) LIKE LOWER(CONCAT('%', :search, '%')) " +
+           "ORDER BY t.name")
+    List<Team> searchTeams(@Param("search") String search);
 
     boolean existsByMlbId(Integer mlbId);
 }

--- a/frontend/src/components/common/Header.tsx
+++ b/frontend/src/components/common/Header.tsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom';
 import { useAuth } from '../../contexts/AuthContext';
 import { useTheme } from '../../contexts/ThemeContext';
+import SearchBar from './SearchBar';
 import './Header.css';
 
 function Header() {
@@ -12,6 +13,7 @@ function Header() {
       <Link to="/" style={{ color: 'white', textDecoration: 'none' }}>
         <h1>MLB Stats</h1>
       </Link>
+      <SearchBar />
       <div className="header-right">
         <a
           href="https://github.com/grovecj/mlb-stats"

--- a/frontend/src/components/common/SearchBar.css
+++ b/frontend/src/components/common/SearchBar.css
@@ -1,0 +1,134 @@
+.search-bar-container {
+  position: relative;
+  flex: 1;
+  max-width: 300px;
+  margin: 0 20px;
+}
+
+.search-form {
+  display: flex;
+  align-items: center;
+  position: relative;
+}
+
+.search-input {
+  width: 100%;
+  padding: 8px 12px;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  border-radius: 4px;
+  background: rgba(255, 255, 255, 0.15);
+  color: white;
+  font-size: 14px;
+  outline: none;
+  transition: background-color 0.2s, border-color 0.2s;
+}
+
+.search-input::placeholder {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.search-input:focus {
+  background: rgba(255, 255, 255, 0.25);
+  border-color: rgba(255, 255, 255, 0.5);
+}
+
+.search-spinner {
+  position: absolute;
+  right: 10px;
+  width: 16px;
+  height: 16px;
+  border: 2px solid rgba(255, 255, 255, 0.3);
+  border-top-color: white;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.search-dropdown {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  right: 0;
+  background: var(--card-background);
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  max-height: 400px;
+  overflow-y: auto;
+  z-index: 1000;
+}
+
+.search-section {
+  padding: 4px 0;
+}
+
+.search-section:not(:last-child) {
+  border-bottom: 1px solid var(--border-color);
+}
+
+.search-section-header {
+  padding: 8px 12px 4px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  color: var(--text-light);
+  letter-spacing: 0.5px;
+}
+
+.search-result-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  padding: 10px 12px;
+  background: none;
+  border: none;
+  text-align: left;
+  cursor: pointer;
+  transition: background-color 0.15s;
+}
+
+.search-result-item:hover {
+  background: var(--border-color);
+}
+
+.search-result-name {
+  color: var(--text-color);
+  font-size: 14px;
+}
+
+.search-result-meta {
+  color: var(--text-light);
+  font-size: 12px;
+}
+
+.search-no-results {
+  padding: 16px 12px;
+  text-align: center;
+  color: var(--text-light);
+  font-size: 14px;
+}
+
+/* Responsive styles */
+@media (max-width: 768px) {
+  .search-bar-container {
+    max-width: 200px;
+    margin: 0 12px;
+  }
+
+  .search-input {
+    padding: 6px 10px;
+    font-size: 13px;
+  }
+}
+
+@media (max-width: 600px) {
+  .search-bar-container {
+    display: none;
+  }
+}

--- a/frontend/src/components/common/SearchBar.tsx
+++ b/frontend/src/components/common/SearchBar.tsx
@@ -1,0 +1,126 @@
+import { useState, useEffect, useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { globalSearch, SearchResult } from '../../services/api';
+import { event } from '../../utils/analytics';
+import './SearchBar.css';
+
+function SearchBar() {
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<SearchResult | null>(null);
+  const [isOpen, setIsOpen] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  useEffect(() => {
+    if (!query.trim()) {
+      setResults(null);
+      setIsOpen(false);
+      return;
+    }
+
+    const timeoutId = setTimeout(async () => {
+      setIsLoading(true);
+      try {
+        const data = await globalSearch(query.trim());
+        setResults(data);
+        setIsOpen(true);
+      } catch (error) {
+        console.error('Search failed:', error);
+        setResults(null);
+      } finally {
+        setIsLoading(false);
+      }
+    }, 300);
+
+    return () => clearTimeout(timeoutId);
+  }, [query]);
+
+  const handleSelect = (type: 'team' | 'player', id: number, name: string) => {
+    event('search_select', { type, item_id: id, item_name: name, search_term: query });
+    setQuery('');
+    setIsOpen(false);
+    navigate(type === 'team' ? `/teams/${id}` : `/players/${id}`);
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (query.trim()) {
+      event('search_submit', { search_term: query });
+      navigate(`/players?search=${encodeURIComponent(query.trim())}`);
+      setQuery('');
+      setIsOpen(false);
+    }
+  };
+
+  const hasResults = results && (results.teams.length > 0 || results.players.length > 0);
+
+  return (
+    <div className="search-bar-container" ref={containerRef}>
+      <form onSubmit={handleSubmit} className="search-form">
+        <input
+          type="text"
+          className="search-input"
+          placeholder="Search teams & players..."
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          onFocus={() => hasResults && setIsOpen(true)}
+        />
+        {isLoading && <span className="search-spinner" />}
+      </form>
+
+      {isOpen && results && (
+        <div className="search-dropdown">
+          {results.teams.length > 0 && (
+            <div className="search-section">
+              <div className="search-section-header">Teams</div>
+              {results.teams.map((team) => (
+                <button
+                  key={team.id}
+                  className="search-result-item"
+                  onClick={() => handleSelect('team', team.id, team.name)}
+                >
+                  <span className="search-result-name">{team.name}</span>
+                  <span className="search-result-meta">{team.abbreviation}</span>
+                </button>
+              ))}
+            </div>
+          )}
+
+          {results.players.length > 0 && (
+            <div className="search-section">
+              <div className="search-section-header">Players</div>
+              {results.players.map((player) => (
+                <button
+                  key={player.id}
+                  className="search-result-item"
+                  onClick={() => handleSelect('player', player.id, player.fullName)}
+                >
+                  <span className="search-result-name">{player.fullName}</span>
+                  <span className="search-result-meta">{player.position}</span>
+                </button>
+              ))}
+            </div>
+          )}
+
+          {!hasResults && query.trim() && (
+            <div className="search-no-results">No results found</div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default SearchBar;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -35,6 +35,17 @@ async function postJson<T>(url: string): Promise<T> {
   return response.json();
 }
 
+// Search
+export interface SearchResult {
+  teams: Team[];
+  players: Player[];
+}
+
+export async function globalSearch(query: string, limit = 5): Promise<SearchResult> {
+  const params = new URLSearchParams({ q: query, limit: String(limit) });
+  return fetchJson<SearchResult>(`${API_BASE}/search?${params}`);
+}
+
 // Teams
 export async function getTeams(): Promise<Team[]> {
   return fetchJson<Team[]>(`${API_BASE}/teams`);


### PR DESCRIPTION
## Summary

- Adds a search bar to the header that searches both teams and players
- Results appear in a dropdown with teams and players grouped separately
- Clicking a result navigates to the team/player detail page
- Pressing Enter navigates to the players page with the search query
- Search is debounced (300ms) to avoid excessive API calls
- Hidden on mobile (< 600px) due to space constraints

## Implementation

**Backend:**
- New `/api/search?q=<query>&limit=5` endpoint returns up to 5 teams and 5 players
- Team search matches on name, abbreviation, and location (case-insensitive)
- Player search matches on full name (case-insensitive, active players only)

**Frontend:**
- SearchBar component with dropdown results
- Integrated into Header between logo and header-right section
- Uses CSS variables for dark mode compatibility
- GA4 events tracked for search_select and search_submit

Closes #32

## Test plan

<img width="1257" height="799" alt="image" src="https://github.com/user-attachments/assets/3b87f37e-dd96-40f3-82ce-9b06dbf53936" />


- [ ] Type in search bar - results appear after typing stops
- [ ] Click on a team result - navigates to team page
- [ ] Click on a player result - navigates to player page
- [ ] Press Enter - navigates to players page with search query
- [ ] Click outside dropdown - dropdown closes
- [ ] Verify search works in both light and dark mode
- [ ] Verify search hidden on mobile screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)