### PR TITLE
Fix production redirecting to OAuth instead of landing page

### DIFF
--- a/backend/src/main/java/com/mlbstats/common/config/SecurityConfig.java
+++ b/backend/src/main/java/com/mlbstats/common/config/SecurityConfig.java
@@ -42,8 +42,12 @@ public class SecurityConfig {
                 // Public endpoints
                 .requestMatchers("/actuator/health").permitAll()
                 .requestMatchers("/error").permitAll()
-                // Static assets
+                // Static assets and SPA entry points
+                .requestMatchers("/", "/index.html").permitAll()
                 .requestMatchers("/assets/**", "/favicon.ico", "/*.js", "/*.css").permitAll()
+                // Frontend routes (SPA handles auth client-side)
+                .requestMatchers("/teams/**", "/players/**", "/games/**").permitAll()
+                .requestMatchers("/standings", "/leaderboards", "/account", "/admin").permitAll()
                 // Auth endpoints
                 .requestMatchers("/api/auth/**").permitAll()
                 // Public API endpoints


### PR DESCRIPTION
## Summary
- Fix issue where production users are sent directly to Google OAuth login instead of the landing page
- Add permitAll() for SPA entry points (`/`, `/index.html`) and frontend routes in Spring Security config
- Frontend handles auth checks client-side via `/api/auth/me` endpoint

Fixes #130

## Test plan
- [ ] Verify local dev still shows landing page for unauthenticated users
- [ ] Deploy to production and verify users see landing page first
- [ ] Verify login flow still works after clicking "Sign in with Google"
- [ ] Verify protected API endpoints (`/api/teams`, etc.) still require authentication

🤖 Generated with [Claude Code](https://claude.com/claude-code)