### PR TITLE
Fix Flyway out-of-order migration error

### DIFF
--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -21,6 +21,7 @@ spring:
     enabled: true
     locations: classpath:db/migration
     baseline-on-migrate: true
+    out-of-order: true
 
   cache:
     type: caffeine

--- a/backend/src/main/resources/db/migration/V9__game_scheduled_time.sql
+++ b/backend/src/main/resources/db/migration/V9__game_scheduled_time.sql
@@ -1,5 +1,5 @@
 -- Add scheduled game time for calendar views
-ALTER TABLE games ADD COLUMN scheduled_time TIME;
+ALTER TABLE games ADD COLUMN IF NOT EXISTS scheduled_time TIME;
 
 -- Create index for time-based ordering within a date
-CREATE INDEX idx_games_date_time ON games(game_date, scheduled_time);
+CREATE INDEX IF NOT EXISTS idx_games_date_time ON games(game_date, scheduled_time);


### PR DESCRIPTION
## Summary
- Enable Flyway `out-of-order` migrations to fix production deployment failure
- Make V9 migration idempotent with `IF NOT EXISTS` clauses

## Problem
V10 (linescores from #144) was merged to main before V9 (calendar from #145). When deploying, Flyway fails validation because it detects V9 as an unapplied migration with a version lower than already-applied V10:

```
Detected resolved migration not applied to database: 9.
To allow executing this migration, set -outOfOrder=true.
```

## Solution
1. Add `out-of-order: true` to Flyway config in `application.yml`
2. Make V9 migration idempotent with `IF NOT EXISTS` for safety

## Test plan
- [x] Backend tests pass (101 tests)
- [ ] Deploy to production and verify app starts successfully

Fixes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)