### PR TITLE
Add player splits feature (#93)

### DIFF
--- a/backend/src/main/java/com/mlbstats/api/controller/PlayerController.java
+++ b/backend/src/main/java/com/mlbstats/api/controller/PlayerController.java
@@ -229,4 +229,20 @@ public class PlayerController {
 
         return ResponseEntity.ok(playerApiService.comparePlayerStats(playerIds, seasonList, careerMode));
     }
+
+    @GetMapping("/{id}/batting-splits")
+    @Operation(summary = "Get player batting splits", description = "Returns batting splits for a player (home/away, vs LHP/RHP, etc.)")
+    public ResponseEntity<List<BattingSplitDto>> getPlayerBattingSplits(
+            @PathVariable Long id,
+            @RequestParam(required = false) Integer season) {
+        return ResponseEntity.ok(playerApiService.getPlayerBattingSplits(id, season));
+    }
+
+    @GetMapping("/{id}/pitching-splits")
+    @Operation(summary = "Get player pitching splits", description = "Returns pitching splits for a player (home/away, vs LHB/RHB, etc.)")
+    public ResponseEntity<List<PitchingSplitDto>> getPlayerPitchingSplits(
+            @PathVariable Long id,
+            @RequestParam(required = false) Integer season) {
+        return ResponseEntity.ok(playerApiService.getPlayerPitchingSplits(id, season));
+    }
 }

--- a/backend/src/main/java/com/mlbstats/api/dto/BattingSplitDto.java
+++ b/backend/src/main/java/com/mlbstats/api/dto/BattingSplitDto.java
@@ -1,0 +1,84 @@
+package com.mlbstats.api.dto;
+
+import com.mlbstats.domain.stats.PlayerBattingSplit;
+import com.mlbstats.domain.stats.SplitType;
+
+import java.math.BigDecimal;
+
+public record BattingSplitDto(
+        Long id,
+        Long playerId,
+        Long teamId,
+        Integer season,
+        SplitType splitType,
+        String splitTypeDisplay,
+        Integer gamesPlayed,
+        Integer plateAppearances,
+        Integer atBats,
+        Integer runs,
+        Integer hits,
+        Integer doubles,
+        Integer triples,
+        Integer homeRuns,
+        Integer rbi,
+        Integer walks,
+        Integer strikeouts,
+        Integer stolenBases,
+        BigDecimal battingAvg,
+        BigDecimal obp,
+        BigDecimal slg,
+        BigDecimal ops
+) {
+    public static BattingSplitDto fromEntity(PlayerBattingSplit split) {
+        return new BattingSplitDto(
+                split.getId(),
+                split.getPlayer() != null ? split.getPlayer().getId() : null,
+                split.getTeam() != null ? split.getTeam().getId() : null,
+                split.getSeason(),
+                split.getSplitType(),
+                formatSplitType(split.getSplitType()),
+                split.getGamesPlayed(),
+                split.getPlateAppearances(),
+                split.getAtBats(),
+                split.getRuns(),
+                split.getHits(),
+                split.getDoubles(),
+                split.getTriples(),
+                split.getHomeRuns(),
+                split.getRbi(),
+                split.getWalks(),
+                split.getStrikeouts(),
+                split.getStolenBases(),
+                split.getBattingAvg(),
+                split.getObp(),
+                split.getSlg(),
+                split.getOps()
+        );
+    }
+
+    private static String formatSplitType(SplitType type) {
+        return switch (type) {
+            case HOME -> "Home";
+            case AWAY -> "Away";
+            case VS_LHP -> "vs LHP";
+            case VS_RHP -> "vs RHP";
+            case VS_LHB -> "vs LHB";
+            case VS_RHB -> "vs RHB";
+            case FIRST_HALF -> "First Half";
+            case SECOND_HALF -> "Second Half";
+            case MONTH_MAR -> "March";
+            case MONTH_APR -> "April";
+            case MONTH_MAY -> "May";
+            case MONTH_JUN -> "June";
+            case MONTH_JUL -> "July";
+            case MONTH_AUG -> "August";
+            case MONTH_SEP -> "September";
+            case MONTH_OCT -> "October";
+            case DAY -> "Day";
+            case NIGHT -> "Night";
+            case RUNNERS_ON -> "Runners On";
+            case RISP -> "RISP";
+            case BASES_EMPTY -> "Bases Empty";
+        };
+    }
+}

--- a/backend/src/main/java/com/mlbstats/api/dto/PitchingSplitDto.java
+++ b/backend/src/main/java/com/mlbstats/api/dto/PitchingSplitDto.java
@@ -1,0 +1,82 @@
+package com.mlbstats.api.dto;
+
+import com.mlbstats.domain.stats.PlayerPitchingSplit;
+import com.mlbstats.domain.stats.SplitType;
+
+import java.math.BigDecimal;
+
+public record PitchingSplitDto(
+        Long id,
+        Long playerId,
+        Long teamId,
+        Integer season,
+        SplitType splitType,
+        String splitTypeDisplay,
+        Integer gamesPlayed,
+        Integer gamesStarted,
+        BigDecimal inningsPitched,
+        Integer wins,
+        Integer losses,
+        Integer saves,
+        Integer holds,
+        Integer hitsAllowed,
+        Integer earnedRuns,
+        Integer walks,
+        Integer strikeouts,
+        BigDecimal era,
+        BigDecimal whip,
+        BigDecimal kPer9,
+        BigDecimal bbPer9
+) {
+    public static PitchingSplitDto fromEntity(PlayerPitchingSplit split) {
+        return new PitchingSplitDto(
+                split.getId(),
+                split.getPlayer() != null ? split.getPlayer().getId() : null,
+                split.getTeam() != null ? split.getTeam().getId() : null,
+                split.getSeason(),
+                split.getSplitType(),
+                formatSplitType(split.getSplitType()),
+                split.getGamesPlayed(),
+                split.getGamesStarted(),
+                split.getInningsPitched(),
+                split.getWins(),
+                split.getLosses(),
+                split.getSaves(),
+                split.getHolds(),
+                split.getHitsAllowed(),
+                split.getEarnedRuns(),
+                split.getWalks(),
+                split.getStrikeouts(),
+                split.getEra(),
+                split.getWhip(),
+                split.getKPer9(),
+                split.getBbPer9()
+        );
+    }
+
+    private static String formatSplitType(SplitType type) {
+        return switch (type) {
+            case HOME -> "Home";
+            case AWAY -> "Away";
+            case VS_LHP -> "vs LHP";
+            case VS_RHP -> "vs RHP";
+            case VS_LHB -> "vs LHB";
+            case VS_RHB -> "vs RHB";
+            case FIRST_HALF -> "First Half";
+            case SECOND_HALF -> "Second Half";
+            case MONTH_MAR -> "March";
+            case MONTH_APR -> "April";
+            case MONTH_MAY -> "May";
+            case MONTH_JUN -> "June";
+            case MONTH_JUL -> "July";
+            case MONTH_AUG -> "August";
+            case MONTH_SEP -> "September";
+            case MONTH_OCT -> "October";
+            case DAY -> "Day";
+            case NIGHT -> "Night";
+            case RUNNERS_ON -> "Runners On";
+            case RISP -> "RISP";
+            case BASES_EMPTY -> "Bases Empty";
+        };
+    }
+}

--- a/backend/src/main/java/com/mlbstats/api/service/PlayerApiService.java
+++ b/backend/src/main/java/com/mlbstats/api/service/PlayerApiService.java
@@ -8,10 +8,14 @@ import com.mlbstats.domain.player.Player;
 import com.mlbstats.domain.player.PlayerRepository;
 import com.mlbstats.domain.player.PlayerSearchCriteria;
 import com.mlbstats.domain.player.PlayerSpecification;
+import com.mlbstats.domain.stats.PlayerBattingSplit;
+import com.mlbstats.domain.stats.PlayerBattingSplitRepository;
 import com.mlbstats.domain.stats.PlayerBattingStats;
 import com.mlbstats.domain.stats.PlayerBattingStatsRepository;
 import com.mlbstats.domain.stats.PlayerGameBattingRepository;
 import com.mlbstats.domain.stats.PlayerGamePitchingRepository;
+import com.mlbstats.domain.stats.PlayerPitchingSplit;
+import com.mlbstats.domain.stats.PlayerPitchingSplitRepository;
 import com.mlbstats.domain.stats.PlayerPitchingStats;
 import com.mlbstats.domain.stats.PlayerPitchingStatsRepository;
 import lombok.RequiredArgsConstructor;
@@ -37,6 +41,8 @@ public class PlayerApiService {
     private final PlayerPitchingStatsRepository pitchingStatsRepository;
     private final PlayerGameBattingRepository gameBattingRepository;
     private final PlayerGamePitchingRepository gamePitchingRepository;
+    private final PlayerBattingSplitRepository battingSplitRepository;
+    private final PlayerPitchingSplitRepository pitchingSplitRepository;
 
     public PageDto<PlayerDto> getAllPlayers(Pageable pageable) {
         Page<Player> page = playerRepository.findByActiveTrue(pageable);
@@ -478,5 +484,25 @@ public class PlayerApiService {
             case "shutouts" -> stats.shutouts() != null ? java.math.BigDecimal.valueOf(stats.shutouts()) : null;
             default -> null;
         };
+    }
+
+    // Player Splits
+
+    public List<BattingSplitDto> getPlayerBattingSplits(Long playerId, Integer season) {
+        if (season == null) {
+            season = DateUtils.getCurrentSeason();
+        }
+        return battingSplitRepository.findByPlayerIdAndSeason(playerId, season).stream()
+                .map(BattingSplitDto::fromEntity)
+                .toList();
+    }
+
+    public List<PitchingSplitDto> getPlayerPitchingSplits(Long playerId, Integer season) {
+        if (season == null) {
+            season = DateUtils.getCurrentSeason();
+        }
+        return pitchingSplitRepository.findByPlayerIdAndSeason(playerId, season).stream()
+                .map(PitchingSplitDto::fromEntity)
+                .toList();
     }
 }

--- a/frontend/src/components/player/PlayerSplits.tsx
+++ b/frontend/src/components/player/PlayerSplits.tsx
@@ -1,0 +1,194 @@
+import { useState, useEffect } from 'react';
+import { BattingSplit, PitchingSplit } from '../../types/stats';
+import { getPlayerBattingSplits, getPlayerPitchingSplits } from '../../services/api';
+import { getDefaultSeason } from '../../utils/season';
+
+interface PlayerSplitsProps {
+  playerId: number;
+  positionType: string | null;
+}
+
+type SplitCategory = 'location' | 'handedness' | 'half' | 'situation';
+
+function formatAvg(value: number | null): string {
+  if (value === null || value === undefined) return '.---';
+  return value.toFixed(3).replace(/^0/, '');
+}
+
+function formatEra(value: number | null): string {
+  if (value === null || value === undefined) return '--.--';
+  return value.toFixed(2);
+}
+
+function PlayerSplits({ playerId, positionType }: PlayerSplitsProps) {
+  const [battingSplits, setBattingSplits] = useState<BattingSplit[]>([]);
+  const [pitchingSplits, setPitchingSplits] = useState<PitchingSplit[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [category, setCategory] = useState<SplitCategory>('location');
+  const [season, setSeason] = useState(getDefaultSeason());
+
+  const isPitcher = positionType === 'Pitcher';
+
+  useEffect(() => {
+    async function fetchSplits() {
+      setLoading(true);
+      try {
+        if (isPitcher) {
+          const splits = await getPlayerPitchingSplits(playerId, season);
+          setPitchingSplits(splits);
+        } else {
+          const splits = await getPlayerBattingSplits(playerId, season);
+          setBattingSplits(splits);
+        }
+      } catch {
+        // Silently handle - splits may not exist
+      } finally {
+        setLoading(false);
+      }
+    }
+    fetchSplits();
+  }, [playerId, season, isPitcher]);
+
+  const splitTypesByCategory: Record<SplitCategory, string[]> = {
+    location: ['HOME', 'AWAY'],
+    handedness: isPitcher ? ['VS_LHB', 'VS_RHB'] : ['VS_LHP', 'VS_RHP'],
+    half: ['FIRST_HALF', 'SECOND_HALF'],
+    situation: ['RUNNERS_ON', 'RISP', 'BASES_EMPTY'],
+  };
+
+  const categoryLabels: Record<SplitCategory, string> = {
+    location: 'Home/Away',
+    handedness: isPitcher ? 'vs Batter Hand' : 'vs Pitcher Hand',
+    half: 'Season Half',
+    situation: 'Situation',
+  };
+
+  const filteredBattingSplits = battingSplits.filter((s) =>
+    splitTypesByCategory[category].includes(s.splitType)
+  );
+
+  const filteredPitchingSplits = pitchingSplits.filter((s) =>
+    splitTypesByCategory[category].includes(s.splitType)
+  );
+
+  const hasSplits = isPitcher
+    ? filteredPitchingSplits.length > 0
+    : filteredBattingSplits.length > 0;
+
+  if (loading) {
+    return (
+      <div className="section">
+        <h3 className="section-title">Splits</h3>
+        <p>Loading splits...</p>
+      </div>
+    );
+  }
+
+  if (!hasSplits && battingSplits.length === 0 && pitchingSplits.length === 0) {
+    return null; // No splits data available
+  }
+
+  return (
+    <div className="section">
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '16px' }}>
+        <h3 className="section-title" style={{ margin: 0 }}>Splits</h3>
+        <select
+          value={season}
+          onChange={(e) => setSeason(parseInt(e.target.value))}
+          className="form-input"
+          style={{ width: 'auto' }}
+        >
+          {Array.from({ length: 5 }, (_, i) => getDefaultSeason() - i).map((y) => (
+            <option key={y} value={y}>{y}</option>
+          ))}
+        </select>
+      </div>
+
+      <div className="tab-group" style={{ marginBottom: '16px' }}>
+        {(Object.keys(categoryLabels) as SplitCategory[]).map((cat) => (
+          <button
+            key={cat}
+            className={`tab-btn ${category === cat ? 'active' : ''}`}
+            onClick={() => setCategory(cat)}
+          >
+            {categoryLabels[cat]}
+          </button>
+        ))}
+      </div>
+
+      {!hasSplits ? (
+        <p className="text-muted">No {categoryLabels[category]} split data available.</p>
+      ) : isPitcher ? (
+        <table className="data-table">
+          <thead>
+            <tr>
+              <th>Split</th>
+              <th>G</th>
+              <th>IP</th>
+              <th>W</th>
+              <th>L</th>
+              <th>ERA</th>
+              <th>WHIP</th>
+              <th>K</th>
+              <th>BB</th>
+              <th>K/9</th>
+            </tr>
+          </thead>
+          <tbody>
+            {filteredPitchingSplits.map((split) => (
+              <tr key={split.id}>
+                <td><strong>{split.splitTypeDisplay}</strong></td>
+                <td>{split.gamesPlayed}</td>
+                <td>{split.inningsPitched?.toFixed(1) ?? '--'}</td>
+                <td>{split.wins}</td>
+                <td>{split.losses}</td>
+                <td>{formatEra(split.era)}</td>
+                <td>{formatAvg(split.whip)}</td>
+                <td>{split.strikeouts}</td>
+                <td>{split.walks}</td>
+                <td>{split.kPer9?.toFixed(1) ?? '--'}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      ) : (
+        <table className="data-table">
+          <thead>
+            <tr>
+              <th>Split</th>
+              <th>G</th>
+              <th>PA</th>
+              <th>AB</th>
+              <th>H</th>
+              <th>HR</th>
+              <th>RBI</th>
+              <th>AVG</th>
+              <th>OBP</th>
+              <th>SLG</th>
+              <th>OPS</th>
+            </tr>
+          </thead>
+          <tbody>
+            {filteredBattingSplits.map((split) => (
+              <tr key={split.id}>
+                <td><strong>{split.splitTypeDisplay}</strong></td>
+                <td>{split.gamesPlayed}</td>
+                <td>{split.plateAppearances}</td>
+                <td>{split.atBats}</td>
+                <td>{split.hits}</td>
+                <td>{split.homeRuns}</td>
+                <td>{split.rbi}</td>
+                <td>{formatAvg(split.battingAvg)}</td>
+                <td>{formatAvg(split.obp)}</td>
+                <td>{formatAvg(split.slg)}</td>
+                <td>{formatAvg(split.ops)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}
+
+export default PlayerSplits;

--- a/frontend/src/pages/PlayerDetailPage.tsx
+++ b/frontend/src/pages/PlayerDetailPage.tsx
@@ -5,6 +5,7 @@ import { BattingStats, PitchingStats } from '../types/stats';
 import { getPlayer, getPlayerBattingStats, getPlayerPitchingStats } from '../services/api';
 import { usePlayerFavorite } from '../hooks/useFavorite';
 import PlayerStats from '../components/player/PlayerStats';
+import PlayerSplits from '../components/player/PlayerSplits';
 import PlayerGameLog from '../components/player/PlayerGameLog';
 import CareerStats from '../components/player/CareerStats';
 import FavoriteButton from '../components/common/FavoriteButton';
@@ -131,6 +132,10 @@ function PlayerDetailPage() {
       </div>
 
       <PlayerStats battingStats={battingStats} pitchingStats={pitchingStats} />
+
+      {playerId && (
+        <PlayerSplits playerId={playerId} positionType={player.positionType} />
+      )}
 
       {playerId && (
         <PlayerGameLog playerId={playerId} positionType={player.positionType} />

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,7 +1,7 @@
 import { Team, RosterEntry, TeamStanding, TeamAggregateStats } from '../types/team';
 import { Player } from '../types/player';
 import { Game, BoxScore, Linescore, CalendarGame, GameCount } from '../types/game';
-import { BattingStats, PitchingStats, BattingGameLog, PitchingGameLog, PageResponse } from '../types/stats';
+import { BattingStats, PitchingStats, BattingGameLog, PitchingGameLog, PageResponse, BattingSplit, PitchingSplit } from '../types/stats';
 import { PlayerComparisonResponse, PlayerSelection } from '../types/comparison';
 import { FavoritesDashboard } from '../types/dashboard';
 
@@ -141,6 +141,16 @@ export async function getPlayerBattingStats(id: number, season?: number): Promis
 export async function getPlayerPitchingStats(id: number, season?: number): Promise<PitchingStats[]> {
   const params = season ? `?season=${season}` : '';
   return fetchJson<PitchingStats[]>(`${API_BASE}/players/${id}/pitching-stats${params}`);
+}
+
+export async function getPlayerBattingSplits(id: number, season?: number): Promise<BattingSplit[]> {
+  const params = season ? `?season=${season}` : '';
+  return fetchJson<BattingSplit[]>(`${API_BASE}/players/${id}/batting-splits${params}`);
+}
+
+export async function getPlayerPitchingSplits(id: number, season?: number): Promise<PitchingSplit[]> {
+  const params = season ? `?season=${season}` : '';
+  return fetchJson<PitchingSplit[]>(`${API_BASE}/players/${id}/pitching-splits${params}`);
 }
 
 export async function getPlayerBattingGameLog(id: number, season?: number): Promise<BattingGameLog[]> {

--- a/frontend/src/types/stats.ts
+++ b/frontend/src/types/stats.ts
@@ -114,3 +114,62 @@ export interface PitchingGameLog {
   strikes: number | null;
   isStarter: boolean;
 }
+
+export type SplitType =
+  | 'HOME' | 'AWAY'
+  | 'VS_LHP' | 'VS_RHP'
+  | 'VS_LHB' | 'VS_RHB'
+  | 'FIRST_HALF' | 'SECOND_HALF'
+  | 'MONTH_MAR' | 'MONTH_APR' | 'MONTH_MAY' | 'MONTH_JUN'
+  | 'MONTH_JUL' | 'MONTH_AUG' | 'MONTH_SEP' | 'MONTH_OCT'
+  | 'DAY' | 'NIGHT'
+  | 'RUNNERS_ON' | 'RISP' | 'BASES_EMPTY';
+
+export interface BattingSplit {
+  id: number;
+  playerId: number;
+  teamId: number | null;
+  season: number;
+  splitType: SplitType;
+  splitTypeDisplay: string;
+  gamesPlayed: number;
+  plateAppearances: number;
+  atBats: number;
+  runs: number;
+  hits: number;
+  doubles: number;
+  triples: number;
+  homeRuns: number;
+  rbi: number;
+  walks: number;
+  strikeouts: number;
+  stolenBases: number;
+  battingAvg: number | null;
+  obp: number | null;
+  slg: number | null;
+  ops: number | null;
+}
+
+export interface PitchingSplit {
+  id: number;
+  playerId: number;
+  teamId: number | null;
+  season: number;
+  splitType: SplitType;
+  splitTypeDisplay: string;
+  gamesPlayed: number;
+  gamesStarted: number;
+  inningsPitched: number | null;
+  wins: number;
+  losses: number;
+  saves: number;
+  holds: number;
+  hitsAllowed: number;
+  earnedRuns: number;
+  walks: number;
+  strikeouts: number;
+  era: number | null;
+  whip: number | null;
+  kPer9: number | null;
+  bbPer9: number | null;
+}


### PR DESCRIPTION
## Summary

Display home/away, vs LHP/RHP, and situational performance splits on the player detail page.

### Backend Changes
- Add `BattingSplitDto` and `PitchingSplitDto` DTOs
- Add `/api/players/{id}/batting-splits` and `/api/players/{id}/pitching-splits` endpoints
- Add service methods using existing split repositories

### Frontend Changes
- Add TypeScript types for splits
- Create `PlayerSplits` component with tabbed split categories
- Add season selector for historical splits
- Integrate into player detail page between stats and game log

### Split Categories

| Category | Batters | Pitchers |
|----------|---------|----------|
| Location | Home vs Away | Home vs Away |
| Handedness | vs LHP vs RHP | vs LHB vs RHB |
| Season Half | First Half vs Second Half | First Half vs Second Half |
| Situation | Runners On, RISP, Bases Empty | Runners On, RISP, Bases Empty |

### Batting Split Table
Shows: G, PA, AB, H, HR, RBI, AVG, OBP, SLG, OPS

### Pitching Split Table
Shows: G, IP, W, L, ERA, WHIP, K, BB, K/9

## Test plan

- [x] All 119 backend tests pass
- [x] All 28 frontend tests pass
- [x] Frontend builds successfully
- [ ] Verify splits display when data is populated

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)