### PR TITLE
Add gif-clipper database firewall access

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -40,13 +40,21 @@ resource "digitalocean_database_cluster" "postgres" {
   tags = var.tags
 }
 
-# Database firewall - only allow App Platform
+# Database firewall - centralized here since mlb-stats owns the cluster
 resource "digitalocean_database_firewall" "postgres_fw" {
   cluster_id = digitalocean_database_cluster.postgres.id
 
   rule {
     type  = "app"
     value = digitalocean_app.mlb_stats.id
+  }
+
+  dynamic "rule" {
+    for_each = var.gif_clipper_app_id != "" ? [var.gif_clipper_app_id] : []
+    content {
+      type  = "app"
+      value = rule.value
+    }
   }
 }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -125,3 +125,10 @@ variable "new_relic_account_id" {
   type        = string
   default     = ""
 }
+
+# Shared database access
+variable "gif_clipper_app_id" {
+  description = "DigitalOcean App ID for gif-clipper (grants database access)"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
## Summary
- Centralize database firewall management in mlb-stats since it owns the shared PostgreSQL cluster
- Add optional `gif_clipper_app_id` variable to grant gif-clipper app database access
- Uses a dynamic rule block so the firewall rule is only added when the variable is set

## Usage
After deploying the gif-clipper app, set `gif_clipper_app_id` in `terraform.tfvars`:
```hcl
gif_clipper_app_id = "<app-id-from-doctl-apps-list>"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)