### PR TITLE
Limit HikariCP pool size for shared DB cluster

### DIFF
--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -7,6 +7,9 @@ spring:
     username: ${DATABASE_USERNAME:mlbstats}
     password: ${DATABASE_PASSWORD:mlbstats}
     driver-class-name: org.postgresql.Driver
+    hikari:
+      maximum-pool-size: ${HIKARI_MAX_POOL_SIZE:5}
+      minimum-idle: ${HIKARI_MIN_IDLE:2}
 
   jpa:
     hibernate:


### PR DESCRIPTION
## Summary
- Reduces HikariCP connection pool from default 10 to max 5 (min idle 2)
- Prevents `remaining connection slots are reserved for roles with the SUPERUSER attribute` errors on the shared DO PostgreSQL cluster
- Pool size remains configurable via `HIKARI_MAX_POOL_SIZE` and `HIKARI_MIN_IDLE` env vars

## Context
The shared DigitalOcean managed PostgreSQL cluster has ~22 connection slots. With mlb-stats (10), gif-clipper (10), and cartergrove-me (10) all using defaults, the cluster runs out of connections. This change is coordinated across all three repos.

## Test plan
- [ ] Merge and verify deployment succeeds
- [ ] Confirm app functions normally with reduced pool

🤖 Generated with [Claude Code](https://claude.com/claude-code)